### PR TITLE
Create QuantityCompanion trait 

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,17 @@ val mw: String = load toString Megawatts // returns “1.2 MW”
 val gw: String = load toString Gigawatts // returns “0.0012 GW”
 ```
 
+Simple console based conversions (using DSL described below)
+
+```scala
+1.kilograms to Pounds       // returns 2.2046226218487757
+2.1.pounds to Kilograms     // returns 0.952543977
+100.C to Fahrenheit         // returns 212.0
+```
+
 ### Approximations
 Create an implicit Quantity value to be used as a tolerance in approximate equality comparisons.
-Use the `approx` method (`=~` and `~=` operator) like the `equals` method (`==` operator)
+Use the `approx` method (`=~`, `~=`, `≈` operator) like the `equals` method (`==` operator)
 
 ```scala
 implicit val tolerance = Watts(.1)
@@ -155,19 +163,19 @@ load.approx(reading)(Watts(.01)) should be(false)
 
 The `=~` and `≈` are the preferred operators as they have the correct precedence for equality operations.
 The `~=` is provided for those who wish to use a more natural looking approx operator using standard characters.
-However, because of its low precedence, user code may require parenthesis around these comparisons
+However, because of its lower precedence, user code may require parenthesis around these comparisons
 
 ### Vectors
 ** EXPERIMENTAL **
 
 All Quantity types in Squants represent the scalar value of a quantity.
 That is, there is no direction information encoded in any of the Quantity types.
-This is true even for Quantities which are proper vector quantities (ie. Velocity, Acceleration, etc).
+This is true even for Quantities which are normally vector quantities (ie. Velocity, Acceleration, etc).
 
 Vector quantities in Squants are implemented as a case class that takes a variable parameter list of like quantities
 representing a set of point coordinates in Cartesian space.
 The dimensionality of the vector is determined by the number of arguments.
-Most basic vector operations are currently supported (addition, substraction, scaling
+Most basic vector operations are currently supported (addition, subtraction, scaling, cross and dot products)
 
 ```scala
 val vector = QuantityVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3)

--- a/src/main/scala/squants/mass/Mass.scala
+++ b/src/main/scala/squants/mass/Mass.scala
@@ -59,22 +59,11 @@ final class Mass private (val value: Double) extends Quantity[Mass]
 /**
  * Factory singleton for [[squants.mass.Mass]] quantities
  */
-object Mass {
+object Mass extends QuantityCompanion[Mass] {
   private[mass] def apply[A](n: A)(implicit num: Numeric[A]) = new Mass(num.toDouble(n))
-  def apply(s: String): Either[String, Mass] = {
-    val regex = "([-+]?[0-9]*\\.?[0-9]+) *(mcg|mg|g|kg|t|tonnes|lb|oz)".r
-    s match {
-      case regex(value, Micrograms.symbol) ⇒ Right(Micrograms(value.toDouble))
-      case regex(value, Milligrams.symbol) ⇒ Right(Milligrams(value.toDouble))
-      case regex(value, Grams.symbol)      ⇒ Right(Grams(value.toDouble))
-      case regex(value, Kilograms.symbol)  ⇒ Right(Kilograms(value.toDouble))
-      case regex(value, Tonnes.symbol)     ⇒ Right(Tonnes(value.toDouble))
-      case regex(value, "tonnes")          ⇒ Right(Tonnes(value.toDouble))
-      case regex(value, Pounds.symbol)     ⇒ Right(Pounds(value.toDouble))
-      case regex(value, Ounces.symbol)     ⇒ Right(Ounces(value.toDouble))
-      case _                               ⇒ Left(s"Unable to parse $s as Mass")
-    }
-  }
+  def name = "Mass"
+  def units = Set(Micrograms, Milligrams, Grams, Kilograms, Tonnes, Pounds, Ounces)
+  def apply(s: String): Either[String, Mass] = parseString(s)
 }
 
 /**

--- a/src/test/scala/squants/json/MoneySerializer.scala
+++ b/src/test/scala/squants/json/MoneySerializer.scala
@@ -16,7 +16,7 @@ import org.json4s.reflect.TypeInfo
 import org.json4s.JsonAST.JDecimal
 
 /**
- * Provides JSON serialization and deserialization for Squants Money type
+ * Provides JSON serialization and deserialization for Money type
  */
 class MoneySerializer extends Serializer[Money] {
 

--- a/src/test/scala/squants/json/PriceSerializer.scala
+++ b/src/test/scala/squants/json/PriceSerializer.scala
@@ -22,14 +22,14 @@ import org.json4s.JsonAST.JDecimal
 import squants.mass.{ Kilograms, Mass }
 
 /**
- * Provides JSON serialization and deserialization for Squants Price type
- * @tparam T The type of quantity of being priced
+ * Provides JSON serialization and deserialization for Price type
+ * @tparam A The type of quantity of being priced
  */
-trait PriceSerializerT[T <: Quantity[T]] extends Serializer[Price[T]] {
+trait PriceSerializerT[A <: Quantity[A]] extends Serializer[Price[A]] {
 
-  protected def Clazz = classOf[Price[T]]
+  protected def Clazz = classOf[Price[A]]
   def QuantityValidator: String ⇒ Boolean
-  def StringToQuantity: String ⇒ T
+  def StringToQuantity: String ⇒ A
 
   /**
    * Implementation
@@ -41,17 +41,17 @@ trait PriceSerializerT[T <: Quantity[T]] extends Serializer[Price[T]] {
     // is suspect, as some units of different quantity types may use the same symbol.
     // TODO - Come up with better way to verify that this is the Serializer for a given Price[A]
     case (TypeInfo(price, _), json) if Clazz.isAssignableFrom(price) && jsonContainsValidQuantity(json, QuantityValidator) ⇒
-      deserializePrice[T](json, StringToQuantity)
+      deserializePrice[A](json, StringToQuantity)
   }
 
   /**
    * Helper function for deserialization of a Price of any Quantity type
    * @param json JValue to be deserialized
    * @param stringToQuantity Function used to convert a string to a Quantity
-   * @tparam A Quantity Type
+   * @tparam B Quantity Type
    * @return
    */
-  def deserializePrice[A <: Quantity[A]](json: JValue, stringToQuantity: String ⇒ A): Price[A] = json match {
+  def deserializePrice[B <: Quantity[B]](json: JValue, stringToQuantity: String ⇒ B): Price[B] = json match {
     case JObject(List(
       JField("amount", JDecimal(amount)),
       JField("currency", JString(currency)),
@@ -68,10 +68,10 @@ trait PriceSerializerT[T <: Quantity[T]] extends Serializer[Price[T]] {
    * Helper function for serializing a Price of any Quantity Type
    * @param price Price
    * @param unit Unit used for serializing the Quantity part of the price
-   * @tparam A Quantity Type
+   * @tparam B Quantity Type
    * @return
    */
-  def serializePrice[A <: Quantity[A]](price: Price[A], unit: UnitOfMeasure[A]) = {
+  def serializePrice[B <: Quantity[B]](price: Price[B], unit: UnitOfMeasure[B]) = {
     JObject(
       List(
         "amount" -> JDecimal(price.money.value),

--- a/src/test/scala/squants/json/QuantitySerializer.scala
+++ b/src/test/scala/squants/json/QuantitySerializer.scala
@@ -17,17 +17,18 @@ import org.json4s.reflect.TypeInfo
 import org.json4s.JsonAST.JString
 import org.json4s.JsonAST.JInt
 import org.json4s.JsonAST.JDecimal
+import squants.mass.{ MassConversions, Mass }
 
 /**
- * Provides JSON serialization and deserialization for Squants Quantity types
+ * Provides JSON serialization and deserialization for Quantity types
  * @param unitOfMeasure - Unit used in JSON
- * @tparam T - The Quantity Type
+ * @tparam A - The Quantity Type
  */
-abstract class QuantitySerializer[T <: Quantity[T]](unitOfMeasure: UnitOfMeasure[T])
-    extends Serializer[T] {
+abstract class QuantitySerializer[A <: Quantity[A]](unitOfMeasure: UnitOfMeasure[A])
+    extends Serializer[A] {
 
   protected def Clazz: Class[_]
-  protected def symbolToUnit: String ⇒ UnitOfMeasure[T]
+  protected def symbolToUnit: String ⇒ Option[UnitOfMeasure[A]]
 
   val c = Clazz
   def deserialize(implicit format: Formats) = {
@@ -35,15 +36,21 @@ abstract class QuantitySerializer[T <: Quantity[T]](unitOfMeasure: UnitOfMeasure
       case JObject(List(
         JField("value", JDecimal(value)),
         JField("unit", JString(unit)))) ⇒
-        symbolToUnit(unit)(value.toDouble)
+        symbolToUnit(unit) match {
+          case Some(u) ⇒ u(value)
+          case None    ⇒ throw new Exception(s"Could not find matching unit for symbol $unit")
+        }
       case JObject(List(
         JField("value", JInt(value)),
         JField("unit", JString(unit)))) ⇒
-        symbolToUnit(unit)(value.toDouble)
+        symbolToUnit(unit) match {
+          case Some(u) ⇒ u(value)
+          case None    ⇒ throw new Exception(s"Could not find matching unit for symbol $unit")
+        }
     }
   }
 
-  def serializeQuantity(q: Quantity[T]) =
+  def serializeQuantity(q: Quantity[A]) =
     JObject(
       List(
         "value" -> JDecimal(q.to(unitOfMeasure)),
@@ -59,7 +66,7 @@ class PowerSerializer(unitOfMeasure: UnitOfMeasure[Power])
   protected val symbolToUnit = Map(
     Kilowatts.symbol -> Kilowatts,
     Megawatts.symbol -> Megawatts,
-    Gigawatts.symbol -> Gigawatts)
+    Gigawatts.symbol -> Gigawatts).get _
   def serialize(implicit format: Formats) = {
     case p: Power ⇒ serializeQuantity(p)
   }
@@ -72,8 +79,17 @@ class TimeSerializer(unitOfMeasure: UnitOfMeasure[Time])
     Milliseconds.symbol -> Milliseconds,
     Seconds.symbol -> Seconds,
     Minutes.symbol -> Minutes,
-    Hours.symbol -> Hours)
+    Hours.symbol -> Hours).get _
   def serialize(implicit format: Formats) = {
     case t: Time ⇒ serializeQuantity(t)
+  }
+}
+
+class MassSerializer(unitOfMeasure: UnitOfMeasure[Mass])
+    extends QuantitySerializer[Mass](unitOfMeasure) {
+  protected val Clazz = classOf[Mass]
+  protected val symbolToUnit = Mass.symbolToUnit _
+  def serialize(implicit format: Formats) = {
+    case m: Mass ⇒ serializeQuantity(m)
   }
 }

--- a/src/test/scala/squants/json/QuantitySerializerSpec.scala
+++ b/src/test/scala/squants/json/QuantitySerializerSpec.scala
@@ -26,6 +26,7 @@ class QuantitySerializerSpec extends FlatSpec with MustMatchers {
       new MassPriceSerializer(Pounds) +
       new MoneySerializer +
       new TimeSerializer(Seconds) +
+      new MassSerializer(Pounds) +
       new TimePriceSerializer(Hours)
   }
 
@@ -94,6 +95,11 @@ class QuantitySerializerSpec extends FlatSpec with MustMatchers {
     time4 must be(Hours(seedValue))
     val time5 = read[Time](jsonTimeInt)
     time5 must be(Seconds(seedValueInt))
+  }
+
+  it must "serialize a Mass value" in {
+    val json = write[Mass](Pounds(seedValue))
+    println(json)
   }
 
   behavior of "MoneySerializer"

--- a/src/test/scala/squants/mass/MassSpec.scala
+++ b/src/test/scala/squants/mass/MassSpec.scala
@@ -36,6 +36,18 @@ class MassSpec extends FlatSpec with Matchers {
     Ounces(10.22).toOunces should be(10.22)
   }
 
+  it should "create values from properly formatted Strings" in {
+    Mass("10.22 mcg").right.get should be(Micrograms(10.22))
+    Mass("10.22 mg").right.get should be(Milligrams(10.22))
+    Mass("10.22 g").right.get should be(Grams(10.22))
+    Mass("10.22 kg").right.get should be(Kilograms(10.22))
+    Mass("10.22 t").right.get should be(Tonnes(10.22))
+    Mass("10.22 lb").right.get should be(Pounds(10.22))
+    Mass("10.22 oz").right.get should be(Ounces(10.22))
+    Mass("10.45 zz").left.get should be("Unable to parse 10.45 zz as Mass")
+    Mass("zz g").left.get should be("Unable to parse zz g as Mass")
+  }
+
   it should "properly convert to all supported Units of Measure" in {
     val x = Grams(1)
     x.toMicrograms should be(1 / MetricSystem.Micro)
@@ -149,10 +161,10 @@ class MassSpec extends FlatSpec with Matchers {
     "10.45 g".toMass.right.get should be(Grams(10.45))
     "10.45 kg".toMass.right.get should be(Kilograms(10.45))
     "10.45 t".toMass.right.get should be(Tonnes(10.45))
-    "10.45 tonnes".toMass.right.get should be(Tonnes(10.45))
     "10.45 lb".toMass.right.get should be(Pounds(10.45))
     "10.45 oz".toMass.right.get should be(Ounces(10.45))
     "10.45 zz".toMass.left.get should be("Unable to parse 10.45 zz as Mass")
+    "zz oz".toMass.left.get should be("Unable to parse zz oz as Mass")
   }
 
   it should "provide Numeric support" in {


### PR DESCRIPTION
Create QuantityCompanion trait to house common Quantity Type level data and behavior (currently implemented in Mass only).

Modify `to` method to account for quantities using other than ValueUnit as valueUnit (to support future improvements).

Other general improvements that do not impact API or implementation.

Additions to README
