### PR TITLE
Tracking dimensions at type level

### DIFF
--- a/shared/src/main/scala/squants/DimensionOrder.scala
+++ b/shared/src/main/scala/squants/DimensionOrder.scala
@@ -7,8 +7,8 @@ trait DimensionOrder[D] {
 }
 object DimensionOrder {
   type Aux[D, Index] = DimensionOrder[D] { type I = Index }
-  implicit val lengthIs1: Aux[Length, _1] = null
-  implicit val massIs2: Aux[Mass, _2] = null
-  implicit val timeIs3: Aux[Time, _3] = null
-  implicit val energyIs4: Aux[Energy, _4] = null
+  implicit val lengthIs1: DimensionOrder[Length] { type I = _1 } = null
+  implicit val massIs2: Dimension[Mass] { type I = _2 } = null
+  implicit val timeIs3: Dimension[Time] { type I = _3 } = null
+  implicit val energyIs4: Dimension[Energy] { type I = _4 } = null
 }

--- a/shared/src/main/scala/squants/DimensionOrder.scala
+++ b/shared/src/main/scala/squants/DimensionOrder.scala
@@ -3,12 +3,41 @@ package squants
 import squants.TypeLevelInt._
 
 trait DimensionOrder[D] {
-  type I <: Pos
+  type DimensionIndex <: TypeLevelInt
 }
+
+trait DimensionIsEarlierThan[D1, D2]
+
+
 object DimensionOrder {
-  type Aux[D, Index] = DimensionOrder[D] { type I = Index }
-  implicit val lengthIs1: DimensionOrder[Length] { type I = _1 } = null
-  implicit val massIs2: Dimension[Mass] { type I = _2 } = null
-  implicit val timeIs3: Dimension[Time] { type I = _3 } = null
-  implicit val energyIs4: Dimension[Energy] { type I = _4 } = null
+
+  implicit val lengthIs1 = new DimensionOrder[Length] { type DimensionIndex = _1 }
+  implicit val massIs2 = new DimensionOrder[Mass] { type DimensionIndex = _2 }
+  implicit val timeIs3 = new DimensionOrder[Time] { type DimensionIndex = _3 }
+  implicit val energyIs4 = new DimensionOrder[Energy] { type DimensionIndex = _4 }
+
+  /**
+    * SingletonOf[T, U] represents an implicit value of type T narrowed to its
+    * singleton type U.
+    * This crazy trick is described here https://gist.github.com/milessabin/cadd73b7756fe4097ca0
+    * and here https://meta.plasm.us/posts/2015/07/11/roll-your-own-scala/
+    */
+  case class SingletonOf[T, U <: { type DimensionIndex <: TypeLevelInt }](u: U)
+
+  object SingletonOf {
+    implicit def mkSingletonOf[T <: { type DimensionIndex <: TypeLevelInt }](implicit
+      t: T
+    ): SingletonOf[T, t.type] = SingletonOf(t)
+  }
+  implicit def isEarlierDimensionByDimensionOrderTC[
+    D1,
+    D2,
+    DO1 <: { type DimensionIndex <: TypeLevelInt },
+    DO2 <: { type DimensionIndex <: TypeLevelInt }
+  ](
+    implicit
+    singletonOfDO1: SingletonOf[DimensionOrder[D1], DO1],
+    singletonOfDO2: SingletonOf[DimensionOrder[D2], DO2],
+    isEarlier: TypeLevelInt.LT[DO1#DimensionIndex, DO2#DimensionIndex]
+  ) = new DimensionIsEarlierThan[D1, D2] {}
 }

--- a/shared/src/main/scala/squants/DimensionOrder.scala
+++ b/shared/src/main/scala/squants/DimensionOrder.scala
@@ -1,0 +1,14 @@
+package squants
+
+import squants.TypeLevelInt._
+
+trait DimensionOrder[D] {
+  type I <: Pos
+}
+object DimensionOrder {
+  type Aux[D, Index] = DimensionOrder[D] { type I = Index }
+  implicit val lengthIs1: Aux[Length, _1] = null
+  implicit val massIs2: Aux[Mass, _2] = null
+  implicit val timeIs3: Aux[Time, _3] = null
+  implicit val energyIs4: Aux[Energy, _4] = null
+}

--- a/shared/src/main/scala/squants/DimensionOrder.scala
+++ b/shared/src/main/scala/squants/DimensionOrder.scala
@@ -8,7 +8,19 @@ trait DimensionOrder[D] {
 
 trait DimensionIsEarlierThan[D1, D2]
 
-
+object DimensionIsEarlierThan {
+  implicit def isEarlierDimensionByDimensionOrderTC[
+  D1,
+  D2,
+  DO1 <: { type DimensionIndex <: TypeLevelInt },
+  DO2 <: { type DimensionIndex <: TypeLevelInt }
+  ](
+    implicit
+    singletonOfDO1: DimensionOrder.SingletonOf[DimensionOrder[D1], DO1],
+    singletonOfDO2: DimensionOrder.SingletonOf[DimensionOrder[D2], DO2],
+    isEarlier: TypeLevelInt.LT[DO1#DimensionIndex, DO2#DimensionIndex]
+  ) = new DimensionIsEarlierThan[D1, D2] {}
+}
 object DimensionOrder {
 
   implicit val lengthIs1 = new DimensionOrder[Length] { type DimensionIndex = _1 }
@@ -29,15 +41,4 @@ object DimensionOrder {
       t: T
     ): SingletonOf[T, t.type] = SingletonOf(t)
   }
-  implicit def isEarlierDimensionByDimensionOrderTC[
-    D1,
-    D2,
-    DO1 <: { type DimensionIndex <: TypeLevelInt },
-    DO2 <: { type DimensionIndex <: TypeLevelInt }
-  ](
-    implicit
-    singletonOfDO1: SingletonOf[DimensionOrder[D1], DO1],
-    singletonOfDO2: SingletonOf[DimensionOrder[D2], DO2],
-    isEarlier: TypeLevelInt.LT[DO1#DimensionIndex, DO2#DimensionIndex]
-  ) = new DimensionIsEarlierThan[D1, D2] {}
 }

--- a/shared/src/main/scala/squants/DimensionSum.scala
+++ b/shared/src/main/scala/squants/DimensionSum.scala
@@ -25,9 +25,12 @@ object DimensionSum {
     D <: Quantity[D],
     E1 <: TypeLevelInt,
     E2 <: TypeLevelInt,
+    S <: { type Out <: TypeLevelInt },
     R1 <: HList,
     R2 <: HList
   ](implicit
+    negateSingleton: TypeLevelInt.SingletonOf[Negate[E1], S],
+    doesNotCancelOut: S#Out <:!< E2,
     exponentSum: Sum[E1, E2],
     dimSum: DimensionSum[R1, R2]
   ): Aux[(D, E1) :: R1, (D, E2) :: R2, (D, exponentSum.Out) :: dimSum.Out] = new DimensionSum[(D, E1) :: R1, (D, E2) :: R2] {

--- a/shared/src/main/scala/squants/DimensionSum.scala
+++ b/shared/src/main/scala/squants/DimensionSum.scala
@@ -26,6 +26,42 @@ object DimensionSum {
     type Out = (D, S) :: O
   }
 
+  implicit def hListPlusHListOfLaterDimension[
+    D1,
+    D2,
+    I1 <: Pos,
+    I2 <: Pos,
+    E1 <: TypeLevelInt,
+    R1 <: HList,
+    A <: (D1, E1) :: R1,
+    B <: HList,
+    O <: HList
+  ](implicit
+    d1HasIndexI1: DimensionOrder.Aux[D1, I1],
+    d2HasIndexI2: DimensionOrder.Aux[D2, I2],
+    d1beforeD2: TypeLevelInt.LT[I1, I2],
+    dimSum: Aux[R1, B, O]
+  ): Aux[A, B, (D1, E1) :: O] = new DimensionSum[A, B] {
+    type Out = (D1, E1) :: O
+  }
+  implicit def hListPlusHListOfEarlierDimension[
+  D1,
+  D2,
+  I1 <: Pos,
+  I2 <: Pos,
+  E1 <: TypeLevelInt,
+  R1 <: HList,
+  A <: (D1, E1) :: R1,
+  B <: HList,
+  O <: HList
+  ](implicit
+    d1HasIndexI1: DimensionOrder.Aux[D1, I1],
+    d2HasIndexI2: DimensionOrder.Aux[D2, I2],
+    d2beforeD1: TypeLevelInt.LT[I2, I1],
+    dimSum: Aux[R1, B, O]
+  ): Aux[A, B, (D1, E1) :: O] = new DimensionSum[A, B] {
+    type Out = (D1, E1) :: O
+  }
   type HLength = (Length, _1) :: HNil
   type HArea = (Length, _2) :: HNil
   type HVolume = (Length, _3) :: HNil
@@ -37,4 +73,6 @@ object DimensionSum {
   implicit val absurdButWorking = hListPlusHList[Length, _1, _2, _3, (Mass, _2) :: HNil, (Mass, _1) :: HNil, (Length, _1) :: (Mass, _2) :: HNil, (Length, _2) :: (Mass, _1) :: HNil, (Mass, _3) :: HNil]
   val test2 = implicitly[DimensionSum[(Length, _1) :: HNil, (Length, _2) :: HNil]]
 
+  implicit val differentLists: Aux[(Length, _4) :: HNil, (Mass, _2) :: HNil, (Length, _4) :: (Mass, _2) :: HNil] = hListPlusHListOfLaterDimension[Length, Mass, _1, _2, _4, HNil, (Length, _4) :: HNil, (Mass, _2) :: HNil, (Mass, _2) :: HNil]
+  val test3 = implicitly[DimensionSum[(Length, _4) :: HNil, (Mass, _2) :: HNil]]
 }

--- a/shared/src/main/scala/squants/DimensionSum.scala
+++ b/shared/src/main/scala/squants/DimensionSum.scala
@@ -1,0 +1,40 @@
+package squants
+
+import squants.TypeLevelInt._
+
+
+trait DimensionSum[A <: HList, B <: HList] {
+  type Out <: HList
+}
+
+object DimensionSum {
+  type Aux[A <: HList, B <: HList, O <: HList] = DimensionSum[A, B] { type Out = O }
+  def apply[A <: HList, B <: HList](implicit sum: DimensionSum[A, B]): Aux[A, B, sum.Out] = sum
+
+  implicit def hNilPlus[B <: HList]: Aux[HNil, B, B] = new DimensionSum[HNil, B] { type Out = B }
+  implicit def hListPlusHList[
+    D,
+    E1 <: TypeLevelInt,
+    E2 <: TypeLevelInt,
+    S <: TypeLevelInt,
+    R1 <: HList,
+    R2 <: HList,
+    A <: (D, E1) :: R1,
+    B <: (D, E2) :: R2,
+    O <: HList
+  ](implicit exponentSum: Sum.Aux[E1, E2, S], dimSum: Aux[R1, R2, O]): Aux[A, B, (D, S) :: O] = new DimensionSum[A, B] {
+    type Out = (D, S) :: O
+  }
+
+  type HLength = (Length, _1) :: HNil
+  type HArea = (Length, _2) :: HNil
+  type HVolume = (Length, _3) :: HNil
+
+  implicit val volumeIsLengthTimesArea = hListPlusHList[Length, _1, _2, _3, HNil, HNil, (Length, _1) :: HNil, (Length, _2) :: HNil, HNil]
+  val test = implicitly[DimensionSum[(Length, _1) :: HNil, (Length, _2) :: HNil]]
+
+  implicit val massCubed: Aux[(Mass, _2) :: HNil, (Mass, _1) :: HNil, (Mass, _3) :: HNil] = hListPlusHList[Mass, _2, _1, _3, HNil, HNil, (Mass, _2) :: HNil, (Mass, _1) :: HNil, HNil]
+  implicit val absurdButWorking = hListPlusHList[Length, _1, _2, _3, (Mass, _2) :: HNil, (Mass, _1) :: HNil, (Length, _1) :: (Mass, _2) :: HNil, (Length, _2) :: (Mass, _1) :: HNil, (Mass, _3) :: HNil]
+  val test2 = implicitly[DimensionSum[(Length, _1) :: HNil, (Length, _2) :: HNil]]
+
+}

--- a/shared/src/main/scala/squants/DimensionSum.scala
+++ b/shared/src/main/scala/squants/DimensionSum.scala
@@ -26,6 +26,23 @@ object DimensionSum {
     type Out = (D, S) :: O
   }
 
+  implicit def hListPlusHListCancellingOut[
+  D,
+  E1 <: TypeLevelInt,
+  E2 <: TypeLevelInt,
+  S <: Negate.Aux[E1, E2],
+  R1 <: HList,
+  R2 <: HList,
+  A <: (D, E1) :: R1,
+  B <: (D, E2) :: R2,
+  O <: HList
+  ](implicit dimSum: Aux[R1, R2, O]): Aux[A, B, O] = new DimensionSum[A, B] {
+    type Out = O
+  }
+  implicit val partiallyCancellingOut = hListPlusHListCancellingOut[
+    Length, _1, _M1, Negate.Aux[_1, _M1], HNil, (Mass, _4) :: HNil, (Length, _1) :: HNil, (Length, _M1) :: (Mass, _4) :: HNil, (Mass, _4) :: HNil]
+  val test5 = implicitly[DimensionSum[(Length, _1) :: HNil, (Length, _M1) :: (Mass, _4) :: HNil]]
+
   implicit def hListPlusHListOfLaterDimension[
     D1,
     D2,

--- a/shared/src/main/scala/squants/DimensionSum.scala
+++ b/shared/src/main/scala/squants/DimensionSum.scala
@@ -84,6 +84,6 @@ object DimensionSum {
 
   class SingletonOf[T, U <: { type Out <: HList }](u: U)
   object SingletonOf {
-    def mkSingleton[T <: { type Out <: HList }](implicit t: T): SingletonOf[T, t.type] = new SingletonOf(t)
+    implicit def mkSingleton[T <: { type Out <: HList }](implicit t: T): SingletonOf[T, t.type] = new SingletonOf(t)
   }
 }

--- a/shared/src/main/scala/squants/DimensionType.scala
+++ b/shared/src/main/scala/squants/DimensionType.scala
@@ -1,3 +1,9 @@
 package squants
 
-trait DimensionType[D, N <: TypeLevelInt]
+trait DimensionType[D <: HList]
+
+object DimensionType {
+  type OneBaseDimension[A] = DimensionType[A :: HNil]
+  type TwoBaseDimensions[A , B] = DimensionType[A :: B :: HNil]
+  type ThreeBaseDimensions[A, B, C] = DimensionType[A :: B :: C :: HNil]
+}

--- a/shared/src/main/scala/squants/DimensionType.scala
+++ b/shared/src/main/scala/squants/DimensionType.scala
@@ -1,9 +1,15 @@
 package squants
 
-trait DimensionType[D <: HList]
+trait DimensionType {
+  type Dimension <: HList
+}
 
 object DimensionType {
-  type OneBaseDimension[A] = DimensionType[A :: HNil]
-  type TwoBaseDimensions[A , B] = DimensionType[A :: B :: HNil]
-  type ThreeBaseDimensions[A, B, C] = DimensionType[A :: B :: C :: HNil]
+  type Aux[D] = DimensionType { type Dimension = D }
+
+  case class SingletonOf[T, U <: { type Dimension <: HList }](u: U)
+  object SingletonOf {
+    implicit def mkSingleton[T <: { type Dimension <: HList }](implicit t: T):  SingletonOf[T, t.type] =
+      SingletonOf[T, t.type](t)
+  }
 }

--- a/shared/src/main/scala/squants/DimensionType.scala
+++ b/shared/src/main/scala/squants/DimensionType.scala
@@ -1,0 +1,3 @@
+package squants
+
+trait DimensionType[D, N <: TypeLevelInt]

--- a/shared/src/main/scala/squants/HList.scala
+++ b/shared/src/main/scala/squants/HList.scala
@@ -1,0 +1,37 @@
+package squants
+
+/**
+  * `HList` ADT base trait.
+  *
+  * @author Miles Sabin
+  */
+sealed trait HList extends Product with Serializable
+
+/**
+  * Non-empty `HList` element type.
+  *
+  * @author Miles Sabin
+  */
+final case class ::[+H, +T <: HList](head : H, tail : T) extends HList {
+  override def toString = head match {
+    case _: ::[_, _] => "("+head+") :: "+tail.toString
+    case _ => head+" :: "+tail.toString
+  }
+}
+
+/**
+  * Empty `HList` element type.
+  *
+  * @author Miles Sabin
+  */
+sealed trait HNil extends HList {
+  def ::[H](h : H) = squants.::(h, this)
+  override def toString = "HNil"
+}
+
+/**
+  * Empty `HList` value.
+  *
+  * @author Miles Sabin
+  */
+case object HNil extends HNil

--- a/shared/src/main/scala/squants/IsProductOf.scala
+++ b/shared/src/main/scala/squants/IsProductOf.scala
@@ -1,19 +1,15 @@
 package squants
 
-import squants.TypeLevelInt.Sum
-
-trait IsProductOf[P, A, B]
+trait IsProductOf[P, T <: (_ <: DimensionType[_], _ <: DimensionType[_])]
 
 object IsProductOf {
-  implicit def isProductIfDimensionTypesSumUp[A, B, P, AN <: TypeLevelInt, BN <: TypeLevelInt, PN <: TypeLevelInt, I](
-    implicit dimA: A <:< DimensionType[I, AN],
-    dimB: B <:< DimensionType[I, BN],
-    dimP: P <:< DimensionType[I, PN],
-    baseDimSumCorrect: Sum.Aux[AN, BN, PN]
-  ) = new IsProductOf[P, A, B] {}
-
-  val areaIsLengthTimesLength = implicitly[IsProductOf[Area, Length, Length]]
-  val volumeIsLengthTimesArea = implicitly[IsProductOf[Volume, Length, Area]]
-  val volumeIsAreaTimesLength = implicitly[IsProductOf[Volume, Length, Area]]
-  //val volumeIsAreaTimesArea = implicitly[IsProductOf[Volume, Area, Area]] // Does not compile, as desired
+  implicit def isProductIfDimensionTypesSumUp[
+    LA <: HList,
+    LB <: HList,
+    LP <: HList,
+    DS <: { type Out <: HList }
+  ](
+    implicit singleton: DimensionSum.SingletonOf[DimensionSum[LA, LB], DS],
+    baseDimSumCorrect: DS#Out =:= LP
+  ) = new IsProductOf[DimensionType[LP], (DimensionType[LA], DimensionType[LB])] {}
 }

--- a/shared/src/main/scala/squants/IsProductOf.scala
+++ b/shared/src/main/scala/squants/IsProductOf.scala
@@ -1,0 +1,19 @@
+package squants
+
+import squants.TypeLevelInt.Sum
+
+trait IsProductOf[P, A, B]
+
+object IsProductOf {
+  implicit def isProductIfDimensionTypesSumUp[A, B, P, AN <: TypeLevelInt, BN <: TypeLevelInt, PN <: TypeLevelInt, I](
+    implicit dimA: A <:< DimensionType[I, AN],
+    dimB: B <:< DimensionType[I, BN],
+    dimP: P <:< DimensionType[I, PN],
+    baseDimSumCorrect: Sum.Aux[AN, BN, PN]
+  ) = new IsProductOf[P, A, B] {}
+
+  val areaIsLengthTimesLength = implicitly[IsProductOf[Area, Length, Length]]
+  val volumeIsLengthTimesArea = implicitly[IsProductOf[Volume, Length, Area]]
+  val volumeIsAreaTimesLength = implicitly[IsProductOf[Volume, Length, Area]]
+  //val volumeIsAreaTimesArea = implicitly[IsProductOf[Volume, Area, Area]] // Does not compile, as desired
+}

--- a/shared/src/main/scala/squants/IsProductOf.scala
+++ b/shared/src/main/scala/squants/IsProductOf.scala
@@ -1,15 +1,14 @@
 package squants
 
-trait IsProductOf[P, T <: (_ <: DimensionType[_], _ <: DimensionType[_])]
+trait IsProductOf[P, T <: (_ <: DimensionType, _ <: DimensionType)]
 
 object IsProductOf {
   implicit def isProductIfDimensionTypesSumUp[
-    LA <: HList,
-    LB <: HList,
-    LP <: HList,
-    DS <: { type Out <: HList }
+    A <: DimensionType,
+    B <: DimensionType,
+    P <: DimensionType
   ](
-    implicit singleton: DimensionSum.SingletonOf[DimensionSum[LA, LB], DS],
-    baseDimSumCorrect: DS#Out =:= LP
-  ) = new IsProductOf[DimensionType[LP], (DimensionType[LA], DimensionType[LB])] {}
+    implicit
+    baseDimSumCorrect: DimensionSum.Aux[A#Dimension, B#Dimension, P#Dimension]
+  ) = new IsProductOf[P, (A, B)] {}
 }

--- a/shared/src/main/scala/squants/TypeLevelInt.scala
+++ b/shared/src/main/scala/squants/TypeLevelInt.scala
@@ -39,6 +39,14 @@ object TypeLevelInt {
   type _M8 = MinusOne[_M7]
   type _M9 = MinusOne[_M8]
 
+  case class SingletonOf[T, U <: { type Out <: TypeLevelInt }](u: U)
+
+  object SingletonOf {
+    implicit def mkSingletonOf[T <: { type Out <: TypeLevelInt }](implicit
+      t: T
+    ): SingletonOf[T, t.type] = SingletonOf(t)
+  }
+
   // C is the sum of A and B
   trait Sum[A <: TypeLevelInt, B <: TypeLevelInt] { type Out <: TypeLevelInt }
   object Sum {

--- a/shared/src/main/scala/squants/TypeLevelInt.scala
+++ b/shared/src/main/scala/squants/TypeLevelInt.scala
@@ -1,0 +1,229 @@
+package squants
+
+// like Nat, but for integers
+// Shamelessly borrowed from non https://gist.github.com/non/8396462
+trait TypeLevelInt
+
+// Pos means positive-or-zero, and Neg means negative-or-zero
+trait Pos extends TypeLevelInt { type P <: Pos }
+trait Neg extends TypeLevelInt { type N <: Neg }
+
+class Zero extends Pos with Neg { type N = Zero }
+
+case class PlusOne[P <: Pos]() extends Pos { type X = PlusOne[P] }
+case class MinusOne[N <: Neg]() extends Neg { type X = MinusOne[N] }
+
+object TypeLevelInt {
+
+  type PlusTwo[A <: Pos] = PlusOne[PlusOne[A]]
+
+  type _0 = Zero
+
+  type _1 = PlusOne[_0]
+  type _2 = PlusOne[_1]
+  type _3 = PlusOne[_2]
+  type _4 = PlusOne[_3]
+  type _5 = PlusOne[_4]
+  type _6 = PlusOne[_5]
+  type _7 = PlusOne[_6]
+  type _8 = PlusOne[_7]
+  type _9 = PlusOne[_8]
+
+  type _M1 = MinusOne[_0]
+  type _M2 = MinusOne[_M1]
+  type _M3 = MinusOne[_M2]
+  type _M4 = MinusOne[_M3]
+  type _M5 = MinusOne[_M4]
+  type _M6 = MinusOne[_M5]
+  type _M7 = MinusOne[_M6]
+  type _M8 = MinusOne[_M7]
+  type _M9 = MinusOne[_M8]
+
+  // C is the sum of A and B
+  trait Sum[A <: TypeLevelInt, B <: TypeLevelInt] { type Out <: TypeLevelInt }
+  object Sum {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit sum: Sum[A, B]): Aux[A, B, sum.Out] = sum
+    type Aux[A <: TypeLevelInt, B <: TypeLevelInt, C <: TypeLevelInt] = Sum[A, B] { type Out = C }
+
+    //implicit def plusZero[A <: Z]: Aux[A, Zero, A] = new Sum[A, Zero] { type Out = A }
+    implicit def zeroPlus[B <: TypeLevelInt]: Aux[Zero, B, B] = new Sum[Zero, B] { type Out = B }
+
+    implicit def posPlusPos[A <: Pos, B <: Pos]
+    (implicit sum: Sum[A, PlusOne[B]]): Aux[PlusOne[A], B, sum.Out] = new Sum[PlusOne[A], B] { type Out = sum.Out }
+    implicit def negPlusNeg[A <: Neg, B <: Neg]
+    (implicit sum: Sum[A, MinusOne[B]]): Aux[MinusOne[A], B, sum.Out] = new Sum[MinusOne[A], B] { type Out = sum.Out }
+    implicit def posPlusNeg[A <: Pos, B <: Neg]
+    (implicit sum: Sum[A, B]): Aux[PlusOne[A], MinusOne[B], sum.Out] = new Sum[PlusOne[A], MinusOne[B]] { type Out = sum.Out }
+    implicit def negPlusPos[A <: Neg, B <: Pos]
+    (implicit sum: Sum[A, B]): Aux[MinusOne[A], PlusOne[B], sum.Out] = new Sum[MinusOne[A], PlusOne[B]] { type Out = sum.Out }
+  }
+
+  // C is the difference of A and B
+  trait Diff[A <: TypeLevelInt, B <: TypeLevelInt] { type Out <: TypeLevelInt }
+  object Diff {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit diff: Diff[A, B]): Aux[A, B, diff.Out] = diff
+    type Aux[A <: TypeLevelInt, B <: TypeLevelInt, C <: TypeLevelInt] = Diff[A, B] { type Out = C }
+
+    implicit def minusZero[A <: TypeLevelInt]: Aux[A, Zero, A] = new Diff[A, Zero] { type Out = A }
+
+    implicit def posMinusPos[A <: Pos, B <: Pos](implicit diff: Diff[A, B]): Aux[PlusOne[A], PlusOne[B], diff.Out] =
+      new Diff[PlusOne[A], PlusOne[B]] { type Out = diff.Out }
+    implicit def negMinusNeg[A <: Neg, B <: Neg](implicit diff: Diff[A, B]): Aux[MinusOne[A], MinusOne[B], diff.Out] =
+      new Diff[MinusOne[A], MinusOne[B]] { type Out = diff.Out }
+    implicit def posMinusNeg[A <: Pos, B <: Neg](implicit diff: Diff[PlusOne[A], B]): Aux[A, MinusOne[B], diff.Out] =
+      new Diff[A, MinusOne[B]] { type Out = diff.Out }
+    implicit def negMinusPos[A <: Neg, B <: Pos](implicit diff: Diff[MinusOne[A], B]): Aux[A, PlusOne[B], diff.Out] =
+      new Diff[A, PlusOne[B]] { type Out = diff.Out }
+  }
+
+  // B is the negation of A
+  trait Negate[A <: TypeLevelInt] { type Out <: TypeLevelInt }
+  object Negate {
+    def apply[A <: TypeLevelInt](implicit n: Negate[A]): Aux[A, n.Out] = n
+    type Aux[A <: TypeLevelInt, B <: TypeLevelInt] = Negate[A] { type Out = B }
+    implicit def int[A <: TypeLevelInt](implicit diff: Diff[Zero, A]): Aux[A, diff.Out] =
+      new Negate[A] { type Out = diff.Out }
+  }
+
+  // C is the product of A and B
+  trait Prod[A <: TypeLevelInt, B <: TypeLevelInt] { type Out <: TypeLevelInt }
+  object Prod {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit prod: Prod[A, B]): Aux[A, B, prod.Out] = prod
+    type Aux[A <: TypeLevelInt, B <: TypeLevelInt, C <: TypeLevelInt] = Prod[A, B] { type Out = C }
+
+    implicit def timesZero[A <: TypeLevelInt]: Aux[A, Zero, Zero] = new Prod[A, Zero] { type Out = Zero }
+    implicit def zeroTimes[B <: TypeLevelInt]: Aux[Zero, B, Zero] = new Prod[Zero, B] { type Out = Zero }
+
+    implicit def posTimes[A <: Pos, B <: TypeLevelInt, C <: TypeLevelInt]
+    (implicit prod: Prod.Aux[A, B, C], sum: Sum[C, B]): Aux[PlusOne[A], B, sum.Out] =
+      new Prod[PlusOne[A], B] { type Out = sum.Out }
+
+    implicit def negTimes[A <: Neg, B <: TypeLevelInt, C <: TypeLevelInt]
+    (implicit prod: Prod.Aux[A, B, C], diff: Diff[C, B]): Aux[MinusOne[A], B, diff.Out] =
+      new Prod[MinusOne[A], B] { type Out = diff.Out }
+  }
+
+  trait Quot[A <: TypeLevelInt, B <: TypeLevelInt] { type Out <: TypeLevelInt }
+  object Quot {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit div: Quot[A, B]): Aux[A, B, div.Out] = div
+    type Aux[A <: TypeLevelInt, B <: TypeLevelInt, C <: TypeLevelInt] = Quot[A, B] { type Out = C }
+
+    // zero / pos,neg
+    implicit def zeroDivPos[A <: Pos]: Aux[Zero, PlusOne[A], Zero] =
+      new Quot[Zero, PlusOne[A]] { type Out = Zero }
+    implicit def zeroDivNeg[A <: Neg]: Aux[Zero, MinusOne[A], Zero] =
+      new Quot[Zero, MinusOne[A]] { type Out = Zero }
+
+    // pos / pos
+    implicit def posDivPos1[A <: Pos, B <: Pos]
+    (implicit lt: LT[A, B]): Aux[PlusOne[A], PlusOne[B], Zero] =
+      new Quot[PlusOne[A], PlusOne[B]] { type Out = Zero }
+    implicit def posDivPosN[A <: Pos, B <: Pos, C <: Pos, D <: Pos]
+    (implicit diff: Diff.Aux[PlusOne[A], B, C], div: Quot.Aux[C, B, D]): Aux[PlusOne[A], B, PlusOne[D]] =
+      new Quot[PlusOne[A], B] { type Out = PlusOne[D] }
+
+    // neg / pos
+    implicit def negDivPos1[A <: Neg, B <: Pos, C <: Pos]
+    (implicit na: Negate.Aux[A, C], lt: LT[C, B]): Aux[MinusOne[A], PlusOne[B], Zero] =
+      new Quot[MinusOne[A], PlusOne[B]] { type Out = Zero }
+    implicit def negDivPosN[A <: Neg, B <: Pos, C <: Neg, D <: Neg]
+    (implicit sum: Sum.Aux[MinusOne[A], B, C], div: Quot.Aux[C, B, D]): Aux[MinusOne[A], B, MinusOne[D]] =
+      new Quot[MinusOne[A], B] { type Out = MinusOne[D] }
+
+    // pos / neg
+    implicit def posDivNeg1[A <: Pos, B <: Neg, C <: Pos]
+    (implicit nb: Negate.Aux[B, C], lt: LT[A, C]): Aux[PlusOne[A], MinusOne[B], Zero] =
+      new Quot[PlusOne[A], MinusOne[B]] { type Out = Zero }
+    implicit def posDivNegN[A <: Pos, B <: Neg, C <: Pos, D <: Neg]
+    (implicit diff: Sum.Aux[PlusOne[A], B, C], div: Quot.Aux[C, B, D]): Aux[PlusOne[A], B, MinusOne[D]] =
+      new Quot[PlusOne[A], B] { type Out = MinusOne[D] }
+
+    // neg / neg
+    implicit def negDivNeg1[A <: Neg, B <: Neg]
+    (implicit lt: LT[B, A]): Aux[MinusOne[A], MinusOne[B], Zero] =
+      new Quot[MinusOne[A], MinusOne[B]] { type Out = Zero }
+    implicit def negDivNegN[A <: Neg, B <: Neg, C <: Neg, D <: Pos]
+    (implicit diff: Diff.Aux[MinusOne[A], B, C], div: Quot.Aux[C, B, D]): Aux[MinusOne[A], B, PlusOne[D]] =
+      new Quot[MinusOne[A], B] { type Out = PlusOne[D] }
+  }
+
+  // Out is the remainder of A divided by B
+  trait Mod[A <: TypeLevelInt, B <: TypeLevelInt] { type Out <: TypeLevelInt }
+  object Mod {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit mod: Mod[A, B]): Aux[A, B, mod.Out] = mod
+    type Aux[A <: TypeLevelInt, B <: TypeLevelInt, C <: TypeLevelInt] = Mod[A, B] { type Out = C }
+    implicit def modAux[A <: TypeLevelInt, B <: TypeLevelInt, C <: TypeLevelInt, D <: TypeLevelInt, E <: TypeLevelInt]
+    (implicit div: Quot.Aux[A, B, C], prod: Prod.Aux[C, B, D], diff: Diff.Aux[A, D, E]): Aux[A, B, E] =
+      new Mod[A, B] { type Out = E }
+  }
+
+  // Out is the GCD of A and B (currently broken when there is no gcd)
+  trait Gcd[A <: TypeLevelInt, B <: TypeLevelInt] { type Out <: TypeLevelInt }
+  object Gcd {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit gcd: Gcd[A, B]): Aux[A, B, gcd.Out] = gcd
+    type Aux[A <: TypeLevelInt, B <: TypeLevelInt, C <: TypeLevelInt] = Gcd[A, B] { type Out = C }
+
+    implicit def gcdZero[A <: Pos]: Aux[PlusOne[A], Zero, PlusOne[A]] =
+      new Gcd[PlusOne[A], Zero] { type Out = PlusOne[A] }
+
+    implicit def gcdN[A <: Pos, B <: Pos, C <: Pos, D <: Pos]
+    (implicit gcd: Aux[PlusOne[B], D, C], mod: Mod.Aux[PlusOne[A], PlusOne[B], D]): Aux[PlusOne[A], PlusOne[B], C] =
+      new Gcd[PlusOne[A], PlusOne[B]] { type Out = C }
+  }
+
+  // A is less than B
+  trait LT[A <: TypeLevelInt, B <: TypeLevelInt]
+  object LT {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit lt: A < B) = lt
+    type <[A <: TypeLevelInt, B <: TypeLevelInt] = LT[A, B]
+
+    implicit def lt1[B <: Pos] = new <[Zero, PlusOne[B]] {}
+    implicit def lt2[A <: Neg] = new <[MinusOne[A], Zero] {}
+    implicit def lt3[A <: Neg, B <: Pos] = new <[MinusOne[A], PlusOne[B]] {}
+    implicit def lt4[A <: Pos, B <: Pos](implicit lt : A < B) = new <[PlusOne[A], PlusOne[B]] {}
+    implicit def lt5[A <: Neg, B <: Neg](implicit lt : A < B) = new <[MinusOne[A], MinusOne[B]] {}
+
+  }
+
+  // A is less-than-or-equal-to B
+  trait LTEq[A <: TypeLevelInt, B <: TypeLevelInt]
+  object LTEq {
+    def apply[A <: TypeLevelInt, B <: TypeLevelInt](implicit lteq: A <= B) = lteq
+    type <=[A <: TypeLevelInt, B <: TypeLevelInt] = LTEq[A, B]
+
+    implicit def ltEq1 = new <=[Zero, Zero] {}
+    implicit def ltEq2[B <: Pos] = new <=[Zero, PlusOne[B]] {}
+    implicit def ltEq3[A <: Neg] = new <=[MinusOne[A], Zero] {}
+    implicit def ltEq4[A <: Pos, B <: Pos](implicit lteq : A <= B) = new <=[PlusOne[A], PlusOne[B]] {}
+    implicit def ltEq5[A <: Neg, B <: Neg](implicit lteq : A <= B) = new <=[MinusOne[A], MinusOne[B]] {}
+  }
+
+  // B is the absolute value of A
+  trait Abs[A <: TypeLevelInt] { type Out <: Pos }
+  object Abs {
+    def apply[A <: TypeLevelInt](implicit abs: Abs[A]): Aux[A, abs.Out] = abs
+    type Aux[A <: TypeLevelInt, B <: Pos] = Abs[A] { type Out = B }
+
+    implicit def posAbs[A <: Pos]: Aux[A, A] = new Abs[A] { type Out = A }
+
+    implicit def negAbs[A <: Neg, B <: Pos](implicit abs: Abs.Aux[A, B]): Aux[MinusOne[A], PlusOne[B]] =
+      new Abs[MinusOne[A]] { type Out = PlusOne[abs.Out] }
+  }
+
+  trait ToInt[N <: TypeLevelInt] { def apply(): Int }
+  object ToInt {
+    def apply[N <: TypeLevelInt](implicit toInt: ToInt[N]): ToInt[N] = toInt
+
+    implicit val toIntZero = new ToInt[Zero] { def apply() = 0 }
+
+    implicit def toIntPos[N <: Pos](implicit toIntN: ToInt[N]) =
+      new ToInt[PlusOne[N]] { def apply() = toIntN() + 1 }
+
+    implicit def toIntNeg[N <: Neg](implicit toIntN: ToInt[N]) =
+      new ToInt[MinusOne[N]] { def apply() = toIntN() - 1 }
+  }
+
+  val Zero: Zero = new Zero
+  val One: PlusOne[Zero] = new PlusOne[Zero]
+  val MinusOne: MinusOne[Zero] = new MinusOne[Zero]
+}

--- a/shared/src/main/scala/squants/energy/Energy.scala
+++ b/shared/src/main/scala/squants/energy/Energy.scala
@@ -8,6 +8,8 @@
 
 package squants.energy
 
+import squants.DimensionType.OneBaseDimension
+import squants.TypeLevelInt._1
 import squants._
 import squants.electro.{ Coulombs, ElectricCharge, ElectricPotential, Volts }
 import squants.mass.{ ChemicalAmount, Kilograms }
@@ -26,6 +28,7 @@ import squants.time.{ Time, _ }
  */
 final class Energy private (val value: Double, val unit: EnergyUnit)
     extends Quantity[Energy]
+    with OneBaseDimension[(Energy, _1)]
     with TimeIntegral[Power]
     with SecondTimeIntegral[PowerRamp] {
 

--- a/shared/src/main/scala/squants/energy/Energy.scala
+++ b/shared/src/main/scala/squants/energy/Energy.scala
@@ -8,7 +8,6 @@
 
 package squants.energy
 
-import squants.DimensionType.OneBaseDimension
 import squants.TypeLevelInt._1
 import squants._
 import squants.electro.{ Coulombs, ElectricCharge, ElectricPotential, Volts }
@@ -28,9 +27,10 @@ import squants.time.{ Time, _ }
  */
 final class Energy private (val value: Double, val unit: EnergyUnit)
     extends Quantity[Energy]
-    with OneBaseDimension[(Energy, _1)]
+    with DimensionType
     with TimeIntegral[Power]
     with SecondTimeIntegral[PowerRamp] {
+  type Dimension = (Energy, _1) :: HNil
 
   def dimension = Energy
 

--- a/shared/src/main/scala/squants/mass/AreaDensity.scala
+++ b/shared/src/main/scala/squants/mass/AreaDensity.scala
@@ -8,6 +8,7 @@
 
 package squants.mass
 
+import squants.TypeLevelInt._
 import squants._
 
 /**
@@ -17,7 +18,8 @@ import squants._
  * @param value Double
  */
 final class AreaDensity private (val value: Double, val unit: AreaDensityUnit)
-    extends Quantity[AreaDensity] {
+    extends Quantity[AreaDensity] with DimensionType {
+  type Dimension = (Length, _M2) :: (Mass, _1) :: HNil
 
   def dimension = AreaDensity
 

--- a/shared/src/main/scala/squants/mass/Density.scala
+++ b/shared/src/main/scala/squants/mass/Density.scala
@@ -8,6 +8,7 @@
 
 package squants.mass
 
+import squants.TypeLevelInt._
 import squants._
 
 /**
@@ -17,7 +18,8 @@ import squants._
  * @param value Double
  */
 final class Density private (val value: Double, val unit: DensityUnit)
-    extends Quantity[Density] {
+    extends Quantity[Density] with DimensionType {
+  type Dimension = (Length, _M3) :: (Mass, _1) :: HNil
 
   def dimension = Density
 

--- a/shared/src/main/scala/squants/mass/Mass.scala
+++ b/shared/src/main/scala/squants/mass/Mass.scala
@@ -8,6 +8,7 @@
 
 package squants.mass
 
+import squants.TypeLevelInt._
 import squants.energy.{ Energy, Joules, SpecificEnergy }
 import squants.motion.{ Force, MassFlow, Momentum, _ }
 import squants.space.{ CubicMeters, SquareMeters }
@@ -24,8 +25,10 @@ import squants.{ Acceleration, Energy ⇒ _, Velocity, _ }
  */
 final class Mass private (val value: Double, val unit: MassUnit)
     extends Quantity[Mass]
+    with DimensionType
     with TimeIntegral[MassFlow] {
 
+  type Dimension = (Mass, _1) :: HNil
   def dimension = Mass
 
   protected def timeDerived = KilogramsPerSecond(toKilograms)

--- a/shared/src/main/scala/squants/motion/Acceleration.scala
+++ b/shared/src/main/scala/squants/motion/Acceleration.scala
@@ -9,6 +9,7 @@
 package squants.motion
 
 import squants._
+import squants.TypeLevelInt._
 import squants.space.{ Feet, UsMiles }
 import squants.time.{ Seconds, _ }
 
@@ -22,10 +23,12 @@ import squants.time.{ Seconds, _ }
  */
 final class Acceleration private (val value: Double, val unit: AccelerationUnit)
     extends Quantity[Acceleration]
+    with DimensionType
     with TimeDerivative[Velocity]
     with SecondTimeDerivative[Length]
     with TimeIntegral[Jerk] {
 
+  type Dimension = (Length, _1) :: (Time, _M2) :: HNil
   def dimension = Acceleration
 
   protected[squants] def timeIntegrated = MetersPerSecond(toMetersPerSecondSquared)

--- a/shared/src/main/scala/squants/motion/Velocity.scala
+++ b/shared/src/main/scala/squants/motion/Velocity.scala
@@ -9,6 +9,7 @@
 package squants.motion
 
 import squants.{ Time, _ }
+import squants.TypeLevelInt._
 import squants.space.{ Feet, InternationalMiles, Kilometers, NauticalMiles, UsMiles }
 import squants.time.{ Seconds, _ }
 
@@ -22,10 +23,12 @@ import squants.time.{ Seconds, _ }
  */
 final class Velocity private (val value: Double, val unit: VelocityUnit)
     extends Quantity[Velocity]
+    with DimensionType
     with TimeIntegral[Acceleration]
     with SecondTimeIntegral[Jerk]
     with TimeDerivative[Length] {
 
+  type Dimension = (Length, _1) :: (Time, _M1) :: HNil
   def dimension = Velocity
 
   def timeDerived = MetersPerSecondSquared(toMetersPerSecond)

--- a/shared/src/main/scala/squants/space/Area.scala
+++ b/shared/src/main/scala/squants/space/Area.scala
@@ -8,6 +8,7 @@
 
 package squants.space
 
+import squants.TypeLevelInt._2
 import squants._
 import squants.electro.{ MagneticFlux, MagneticFluxDensity, Webers }
 import squants.energy.Watts
@@ -23,7 +24,7 @@ import squants.radio._
  * @param value value in [[squants.space.SquareMeters]]
  */
 final class Area private (val value: Double, val unit: AreaUnit)
-    extends Quantity[Area] {
+    extends Quantity[Area] with DimensionType[Length, _2]{
 
   def dimension = Area
 

--- a/shared/src/main/scala/squants/space/Area.scala
+++ b/shared/src/main/scala/squants/space/Area.scala
@@ -8,7 +8,6 @@
 
 package squants.space
 
-import squants.DimensionType.OneBaseDimension
 import squants.TypeLevelInt._2
 import squants._
 import squants.electro.{ MagneticFlux, MagneticFluxDensity, Webers }
@@ -25,7 +24,8 @@ import squants.radio._
  * @param value value in [[squants.space.SquareMeters]]
  */
 final class Area private (val value: Double, val unit: AreaUnit)
-    extends Quantity[Area] with OneBaseDimension[(Length, _2)]{
+    extends Quantity[Area] with DimensionType {
+  type Dimension = (Length, _2) :: HNil
 
   def dimension = Area
 

--- a/shared/src/main/scala/squants/space/Area.scala
+++ b/shared/src/main/scala/squants/space/Area.scala
@@ -8,6 +8,7 @@
 
 package squants.space
 
+import squants.DimensionType.OneBaseDimension
 import squants.TypeLevelInt._2
 import squants._
 import squants.electro.{ MagneticFlux, MagneticFluxDensity, Webers }
@@ -24,7 +25,7 @@ import squants.radio._
  * @param value value in [[squants.space.SquareMeters]]
  */
 final class Area private (val value: Double, val unit: AreaUnit)
-    extends Quantity[Area] with DimensionType[Length, _2]{
+    extends Quantity[Area] with OneBaseDimension[(Length, _2)]{
 
   def dimension = Area
 

--- a/shared/src/main/scala/squants/space/Length.scala
+++ b/shared/src/main/scala/squants/space/Length.scala
@@ -8,6 +8,7 @@
 
 package squants.space
 
+import squants.TypeLevelInt._1
 import squants._
 import squants.electro._
 import squants.energy.{ Joules, Watts }
@@ -25,6 +26,7 @@ import squants.time.{ SecondTimeIntegral, TimeIntegral, TimeSquared }
  */
 final class Length private (val value: Double, val unit: LengthUnit)
     extends Quantity[Length]
+    with DimensionType[Length, _1]
     with TimeIntegral[Velocity]
     with SecondTimeIntegral[Acceleration] {
 

--- a/shared/src/main/scala/squants/space/Length.scala
+++ b/shared/src/main/scala/squants/space/Length.scala
@@ -8,7 +8,6 @@
 
 package squants.space
 
-import squants.DimensionType.OneBaseDimension
 import squants.TypeLevelInt._1
 import squants._
 import squants.electro._
@@ -27,10 +26,11 @@ import squants.time.{ SecondTimeIntegral, TimeIntegral, TimeSquared }
  */
 final class Length private (val value: Double, val unit: LengthUnit)
     extends Quantity[Length]
-    with OneBaseDimension[(Length, _1)]
+    with DimensionType
     with TimeIntegral[Velocity]
     with SecondTimeIntegral[Acceleration] {
 
+  type Dimension = (Length, _1) :: HNil
   def dimension = Length
 
   protected def timeDerived = MetersPerSecond(toMeters)

--- a/shared/src/main/scala/squants/space/Length.scala
+++ b/shared/src/main/scala/squants/space/Length.scala
@@ -8,6 +8,7 @@
 
 package squants.space
 
+import squants.DimensionType.OneBaseDimension
 import squants.TypeLevelInt._1
 import squants._
 import squants.electro._
@@ -26,7 +27,7 @@ import squants.time.{ SecondTimeIntegral, TimeIntegral, TimeSquared }
  */
 final class Length private (val value: Double, val unit: LengthUnit)
     extends Quantity[Length]
-    with DimensionType[Length, _1]
+    with OneBaseDimension[(Length, _1)]
     with TimeIntegral[Velocity]
     with SecondTimeIntegral[Acceleration] {
 

--- a/shared/src/main/scala/squants/space/Volume.scala
+++ b/shared/src/main/scala/squants/space/Volume.scala
@@ -8,6 +8,7 @@
 
 package squants.space
 
+import squants.DimensionType.OneBaseDimension
 import squants.TypeLevelInt._3
 import squants._
 import squants.energy.{ EnergyDensity, Joules }
@@ -25,7 +26,7 @@ import squants.time.TimeIntegral
  */
 final class Volume private (val value: Double, val unit: VolumeUnit)
     extends Quantity[Volume]
-      with DimensionType[Length, _3]
+      with OneBaseDimension[(Length, _3)]
       with TimeIntegral[VolumeFlow] {
 
   def dimension = Volume

--- a/shared/src/main/scala/squants/space/Volume.scala
+++ b/shared/src/main/scala/squants/space/Volume.scala
@@ -8,7 +8,6 @@
 
 package squants.space
 
-import squants.DimensionType.OneBaseDimension
 import squants.TypeLevelInt._3
 import squants._
 import squants.energy.{ EnergyDensity, Joules }
@@ -26,9 +25,10 @@ import squants.time.TimeIntegral
  */
 final class Volume private (val value: Double, val unit: VolumeUnit)
     extends Quantity[Volume]
-      with OneBaseDimension[(Length, _3)]
+      with DimensionType
       with TimeIntegral[VolumeFlow] {
 
+  type Dimension = (Length, _3) :: HNil
   def dimension = Volume
 
   protected def timeDerived = CubicMetersPerSecond(toCubicMeters)

--- a/shared/src/main/scala/squants/space/Volume.scala
+++ b/shared/src/main/scala/squants/space/Volume.scala
@@ -8,6 +8,7 @@
 
 package squants.space
 
+import squants.TypeLevelInt._3
 import squants._
 import squants.energy.{ EnergyDensity, Joules }
 import squants.mass.{ ChemicalAmount, Kilograms }
@@ -24,7 +25,8 @@ import squants.time.TimeIntegral
  */
 final class Volume private (val value: Double, val unit: VolumeUnit)
     extends Quantity[Volume]
-    with TimeIntegral[VolumeFlow] {
+      with DimensionType[Length, _3]
+      with TimeIntegral[VolumeFlow] {
 
   def dimension = Volume
 

--- a/shared/src/main/scala/squants/time/Time.scala
+++ b/shared/src/main/scala/squants/time/Time.scala
@@ -8,6 +8,7 @@
 
 package squants.time
 
+import squants.TypeLevelInt._1
 import squants._
 
 import scala.concurrent.duration.{ DAYS, Duration, HOURS, MICROSECONDS, MILLISECONDS, MINUTES, NANOSECONDS, SECONDS }
@@ -22,8 +23,8 @@ import scala.language.implicitConversions
  * @param value value in [[squants.time.Milliseconds]]
  */
 final class Time private (val value: Double, val unit: TimeUnit)
-    extends Quantity[Time] {
-
+    extends Quantity[Time] with DimensionType {
+  type Dimension = (Time, _1) :: HNil
   def dimension = Time
 
   def millis = toMilliseconds.toLong


### PR DESCRIPTION
This PR is used to keep track of an implementation of #127.
It is not yet meant to be merged.
The current state just works for a single "base dimension" like `Length` where it can prove that 

```
IsProductOf[Area, Length, Length]
IsProductOf[Volume, Area, Length]
IsProductOf[Volume, Length, Area]
```
