### PR TITLE
Improve scala.js build and test squantsJS on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_cache:
 script:
   # Your normal script
   - sbt ++$TRAVIS_SCALA_VERSION test:compile test:fastOptJS
-  - sbt ++$TRAVIS_SCALA_VERSION -J-XX:ReservedCodeCacheSize=256M test
+  - sbt ++$TRAVIS_SCALA_VERSION squantsJS/test squantsJVM/test
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -232,12 +232,9 @@ object SquantsBuild extends Build {
     )
     .jsSettings(
       parallelExecution in Test := false,
-      excludeFilter in Test := "*Serializer.scala" || "*SerializerSpec.scala",
-      scalaJSUseRhino in Test := false,
-      requiresDOM in Test  := false,
-      jsEnv in Test := NodeJSEnv().value
+      excludeFilter in Test := "*Serializer.scala" || "*SerializerSpec.scala"
     )
 
- 	lazy val squantsJVM = squants.jvm.enablePlugins(SbtOsgi)
- 	lazy val squantsJS = squants.js
+  lazy val squantsJVM = squants.jvm.enablePlugins(SbtOsgi)
+  lazy val squantsJS = squants.js
 }


### PR DESCRIPTION
It seems scala.js tests are not explicitly executed on travis. This PR explicitly calls them it removes some deprecated settings from the scala.js build