### PR TITLE
Aggregate projects on root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val root = project.in(file("."))
     publishLocal := {},
     publishArtifact := false
   )
+  .aggregate(squantsJVM, squantsJS)
 
 lazy val squantsJVM = squants.jvm.enablePlugins(SbtOsgi)
 lazy val squantsJS = squants.js


### PR DESCRIPTION
This is a tiny change to let commands be run at the top project. e.g. you can run `test` at `root` and it will run `test` at the jvm and js projects.

It is useful for publishing both type of artifacts at once