### PR TITLE
Remove deprecated call

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -54,7 +54,12 @@ object Project {
 
 object Compiler {
   val defaultSettings = Seq(
-    scalacOptions in ThisBuild ++= Seq("-feature", "-deprecation"),
+    scalacOptions in ThisBuild ++= Seq(
+      "-feature",
+      "-deprecation",
+      "-encoding", "UTF-8",       // yes, this is 2 args
+      "-Xfatal-warnings"
+    ),
 
     scalaVersion in ThisBuild := Versions.Scala,
 

--- a/shared/src/test/scala/squants/market/PriceSpec.scala
+++ b/shared/src/test/scala/squants/market/PriceSpec.scala
@@ -77,9 +77,9 @@ class PriceSpec extends FlatSpec with Matchers {
     p * Meters(10) should be(Money(100, "USD"))
   }
 
-  it should "return Quantity when multiplied by Money" in {
+  it should "return Quantity when divided by Money" in {
     val p = Price(Money(10, "USD"), Meters(1))
-    p * Money(40, "USD") should be(Meters(4))
+    Money(40, "USD") / p should be(Meters(4))
   }
 
   it should "return properly formatted strings" in {


### PR DESCRIPTION
We have one deprecation warning on a test, likely related to #133 
This PR fixes it and also enables `fatal-warnings` to avoid letting this happen again in the future