### PR TITLE
don't parse multiple degree symbols and be more flexible in whitespace when parsing temperature

### DIFF
--- a/shared/src/main/scala/squants/thermal/Temperature.scala
+++ b/shared/src/main/scala/squants/thermal/Temperature.scala
@@ -143,19 +143,13 @@ object Temperature extends Dimension[Temperature] with BaseDimension {
   def apply(s: String): Try[Temperature] = {
     val regex = "([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?)*[ ]*°? *(f|F|c|C|k|K|r|R)".r
     s match {
-      case regex(value, Fahrenheit.symbol) ⇒ Success(Fahrenheit(value.toDouble))
-      case regex(value, "f")               ⇒ Success(Fahrenheit(value.toDouble))
-      case regex(value, "F")               ⇒ Success(Fahrenheit(value.toDouble))
-      case regex(value, Celsius.symbol)    ⇒ Success(Celsius(value.toDouble))
-      case regex(value, "c")               ⇒ Success(Celsius(value.toDouble))
-      case regex(value, "C")               ⇒ Success(Celsius(value.toDouble))
-      case regex(value, Kelvin.symbol)     ⇒ Success(Kelvin(value.toDouble))
-      case regex(value, "k")               ⇒ Success(Kelvin(value.toDouble))
-      case regex(value, "K")               ⇒ Success(Kelvin(value.toDouble))
-      case regex(value, Rankine.symbol)    ⇒ Success(Rankine(value.toDouble))
-      case regex(value, "r")               ⇒ Success(Rankine(value.toDouble))
-      case regex(value, "R")               ⇒ Success(Rankine(value.toDouble))
-      case _                               ⇒ Failure(QuantityParseException("Unable to parse Temperature", s))
+      case regex(value, unit) => unit match {
+        case "f" | "F" => Success(Fahrenheit(value.toDouble))
+        case "c" | "C" => Success(Celsius(value.toDouble))
+        case "k" | "K" => Success(Kelvin(value.toDouble))
+        case "r" | "R" => Success(Rankine(value.toDouble))
+      }
+      case _ => Failure(QuantityParseException("Unable to parse Temperature", s))
     }
   }
 

--- a/shared/src/main/scala/squants/thermal/Temperature.scala
+++ b/shared/src/main/scala/squants/thermal/Temperature.scala
@@ -141,7 +141,7 @@ object Temperature extends Dimension[Temperature] with BaseDimension {
   def apply[A](n: A, scale: TemperatureScale)(implicit num: Numeric[A]) = new Temperature(num.toDouble(n), scale)
 
   def apply(s: String): Try[Temperature] = {
-    val regex = "([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?)[ °]*(f|F|c|C|k|K|r|R)".r
+    val regex = "([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?)*[ ]*°? *(f|F|c|C|k|K|r|R)".r
     s match {
       case regex(value, Fahrenheit.symbol) ⇒ Success(Fahrenheit(value.toDouble))
       case regex(value, "f")               ⇒ Success(Fahrenheit(value.toDouble))

--- a/shared/src/main/scala/squants/thermal/Temperature.scala
+++ b/shared/src/main/scala/squants/thermal/Temperature.scala
@@ -141,7 +141,7 @@ object Temperature extends Dimension[Temperature] with BaseDimension {
   def apply[A](n: A, scale: TemperatureScale)(implicit num: Numeric[A]) = new Temperature(num.toDouble(n), scale)
 
   def apply(s: String): Try[Temperature] = {
-    val regex = "([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?)*[ ]*°? *(f|F|c|C|k|K|r|R)".r
+    val regex = "([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?)* *°? *(f|F|c|C|k|K|r|R)".r
     s match {
       case regex(value, unit) => unit match {
         case "f" | "F" => Success(Fahrenheit(value.toDouble))

--- a/shared/src/test/scala/squants/thermal/TemperatureSpec.scala
+++ b/shared/src/test/scala/squants/thermal/TemperatureSpec.scala
@@ -55,6 +55,18 @@ class TemperatureSpec extends FlatSpec with Matchers {
     Temperature("ZZ F").failed.get should be(QuantityParseException("Unable to parse Temperature", "ZZ F"))
   }
 
+  they should "be flexible in parsing strings with regard to degree symbol and whitespace" in {
+    Temperature("10.22 f").get should be (Fahrenheit(10.22))
+    Temperature("10.22 °f").get should be (Fahrenheit(10.22))
+    Temperature("10.22  °f").get should be (Fahrenheit(10.22))
+    Temperature("10.22 ° f").get should be (Fahrenheit(10.22))
+    Temperature("10.22 °   f").get should be (Fahrenheit(10.22))
+    Temperature("10.22  °   f").get should be (Fahrenheit(10.22))
+    Temperature("10.22°f").get should be (Fahrenheit(10.22))
+
+    Temperature("10.22°°f").failed.get should be (QuantityParseException("Unable to parse Temperature", "10.22°°f"))
+  }
+
   they should "properly convert to all supported Units of Measure (Scale)" in {
     val x = Kelvin(0)
     x.toKelvinScale should be(0)


### PR DESCRIPTION
This would fix #189. I adapted the regex slightly from the current pureconfig-squants version.

This disallows multiple degree symbols. Arguably this was a bug. If this PR is merged, we should add a note to the release notes that this is technically a breaking change (we're less liberal in what inputs we parse).

We should also look at the other string parsers to see if they're similarly affected.