### PR TITLE
update contributors list based on git log

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ trait LoadRoute extends HttpService {
 * Jeremy Apthorp ([nornagon](https://github.com/nornagon))
 * Steve Barham ([stevebarham](https://github.com/stevebarham))
 * Derek Morr ([derekmorr](https://github.com/derekmorr))
-* rmihael ([rmihael](https://github.com/rmihael))
+* Michael Korbakov ([rmihael](https://github.com/rmihael))
 * Florian Nussberger ([fnussber](https://github.com/fnussber))
 * Ajay Chandran ([ajaychandran](https://github.com/ajaychandran))
 * Gia Bảo ([giabao](https://github.com/giabao))
@@ -771,6 +771,10 @@ trait LoadRoute extends HttpService {
 * Szabolcs Berecz ([khernyo](https://github.com/khernyo))
 * Matt Hicks ([darkfrog26](https://github.com/darkfrog26))
 * golem131 ([golem131](https://github.com/golem131))
+* Ian O'Hara ([ianohara](https://github.com/ianohara))
+* Shadaj Laddad ([shadaj](https://github.com/shadaj))
+* Ian McIntosh ([cranst0n](https://github.com/cranst0n))
+
 
 ## Code of Conduct
 


### PR DESCRIPTION
Our contributors list is out of date. This corrects is based on `git log`.