### PR TITLE
Add AcreFeet unit to Volume

### DIFF
--- a/shared/src/main/scala/squants/space/Volume.scala
+++ b/shared/src/main/scala/squants/space/Volume.scala
@@ -86,6 +86,8 @@ final class Volume private (val value: Double, val unit: VolumeUnit)
   def toImperialQuarts = to(ImperialQuarts)
   def toImperialPints = to(ImperialPints)
   def toImperialCups = to(ImperialCups)
+
+  def toAcreFeet = to(AcreFeet)
 }
 
 object Volume extends Dimension[Volume] {
@@ -97,7 +99,8 @@ object Volume extends Dimension[Volume] {
   def units = Set(CubicMeters, Litres, Nanolitres, Microlitres, Millilitres, Centilitres,
     Decilitres, Hectolitres,
     CubicUsMiles, CubicYards, CubicFeet, CubicInches,
-    UsGallons, UsQuarts, UsPints, UsCups, FluidOunces, Tablespoons, Teaspoons)
+    UsGallons, UsQuarts, UsPints, UsCups, FluidOunces, Tablespoons, Teaspoons,
+    AcreFeet)
 }
 
 trait VolumeUnit extends UnitOfMeasure[Volume] with UnitConverter {
@@ -238,6 +241,11 @@ object ImperialCups extends VolumeUnit {
   val conversionFactor = ImperialGallons.conversionFactor / 16d
 }
 
+object AcreFeet extends VolumeUnit {
+  val symbol = "acft"
+  val conversionFactor = CubicFeet.conversionFactor * 43560d
+}
+
 object VolumeConversions {
   lazy val cubicMeter = CubicMeters(1)
   lazy val litre = Litres(1)
@@ -269,6 +277,8 @@ object VolumeConversions {
   lazy val tablespoon = Tablespoons(1)
   lazy val teaspoon = Teaspoons(1)
 
+  lazy val acreFoot = AcreFeet(1)
+
   implicit class VolumeConversions[A](n: A)(implicit num: Numeric[A]) {
     def cubicMeters = CubicMeters(n)
     def cubicMetres = CubicMeters(n)
@@ -299,6 +309,8 @@ object VolumeConversions {
     def fluidOunces = FluidOunces(n)
     def tablespoons = Tablespoons(n)
     def teaspoons = Teaspoons(n)
+
+    def acreFeet = AcreFeet(n)
   }
 
   implicit object VolumeNumeric extends AbstractQuantityNumeric[Volume](Volume.primaryUnit)

--- a/shared/src/test/scala/squants/space/VolumeSpec.scala
+++ b/shared/src/test/scala/squants/space/VolumeSpec.scala
@@ -48,6 +48,8 @@ class VolumeSpec extends FlatSpec with Matchers {
     FluidOunces(1).toFluidOunces should be(1)
     Tablespoons(1).toTablespoons should be(1)
     Teaspoons(1).toTeaspoons should be(1)
+
+    AcreFeet(1).toAcreFeet should be(1)
   }
 
   it should "create values from properly formatted Strings" in {
@@ -70,6 +72,7 @@ class VolumeSpec extends FlatSpec with Matchers {
     Volume("10.22 oz").get should be(FluidOunces(10.22))
     Volume("10.22 tbsp").get should be(Tablespoons(10.22))
     Volume("10.22 tsp").get should be(Teaspoons(10.22))
+    Volume("10.22 acft").get should be(AcreFeet(10.22))
     Volume("10.22 zz").failed.get should be(QuantityParseException("Unable to parse Volume", "10.22 zz"))
     Volume("ZZ L").failed.get should be(QuantityParseException("Unable to parse Volume", "ZZ L"))
   }
@@ -111,6 +114,8 @@ class VolumeSpec extends FlatSpec with Matchers {
     x.toImperialQuarts should be(4000d / litresPerImperialGallon)
     x.toImperialPints should be(8000d / litresPerImperialGallon)
     x.toImperialCups should be(16000d / litresPerImperialGallon)
+
+    x.toAcreFeet should be(8.107083295302069E-4)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
@@ -132,6 +137,8 @@ class VolumeSpec extends FlatSpec with Matchers {
     UsQuarts(1).toString(UsQuarts) should be("1.0 qt")
     UsPints(1).toString(UsPints) should be("1.0 pt")
     UsCups(1).toString(UsCups) should be("1.0 c")
+
+    AcreFeet(1).toString(AcreFeet) should be("1.0 acft")
   }
 
   it should "return Mass when multiplied by Density" in {
@@ -194,6 +201,8 @@ class VolumeSpec extends FlatSpec with Matchers {
     fluidOunce should be(FluidOunces(1))
     tablespoon should be(Tablespoons(1))
     teaspoon should be(Teaspoons(1))
+
+    acreFoot should be(AcreFeet(1))
   }
 
   it should "provide implicit conversion from Double" in {
@@ -229,6 +238,8 @@ class VolumeSpec extends FlatSpec with Matchers {
     d.fluidOunces should be(FluidOunces(d))
     d.tablespoons should be(Tablespoons(d))
     d.teaspoons should be(Teaspoons(d))
+
+    d.acreFeet should be(AcreFeet(d))
   }
 
   it should "provide Numeric support" in {


### PR DESCRIPTION
A new unit of volume inspired by recent events at the Oroville Dam.  Acre-feet is a common unit used in the context of water reservoirs.