### PR TITLE
use tut to build docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,10 @@ lazy val squants = crossProject
   .in(file("."))
   .settings(defaultSettings: _*)
   .jvmSettings(
-    osgiSettings: _*
+    osgiSettings,
+    tutSettings,
+    tutTargetDirectory := file("."),
+    tutSourceDirectory := file("shared") / "src" / "main" / "tut"
   )
   .jsSettings(
     parallelExecution in Test := false,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.8")

--- a/shared/src/main/tut/README.md
+++ b/shared/src/main/tut/README.md
@@ -78,15 +78,10 @@ or produced, that is, Power is the first time derivative of Energy.
 
 Consider the following code:
 
-```scala
-scala> val loadKw = 1.2
-loadKw: Double = 1.2
-
-scala> val energyMwh = 24.2
-energyMwh: Double = 24.2
-
-scala> val sumKw = loadKw + energyMwh
-sumKw: Double = 25.4
+```tut
+val loadKw = 1.2
+val energyMwh = 24.2
+val sumKw = loadKw + energyMwh
 ```
 
 This example not only adds quantities of different dimensions (Power vs Energy),
@@ -100,49 +95,28 @@ _Only quantities with the same dimensions may be compared, equated, added, or su
 Squants helps prevent errors like these by type checking operations at compile time and
 automatically applying scale and type conversions at run-time.  For example:
 
-```scala
-scala> import squants.energy.{Kilowatts, Megawatts, Power}
+```tut:reset
 import squants.energy.{Kilowatts, Megawatts, Power}
-
-scala> val load1: Power = Kilowatts(12)
-load1: squants.energy.Power = 12.0 kW
-
-scala> val load2: Power = Megawatts(0.023)
-load2: squants.energy.Power = 0.023 MW
-
-scala> val sum = load1 + load2
-sum: squants.energy.Power = 35.0 kW
-
-scala> sum == Kilowatts(35)
-res0: Boolean = true
-
-scala> sum == Megawatts(0.035) // comparisions automatically convert scale
-res1: Boolean = true
+val load1: Power = Kilowatts(12)
+val load2: Power = Megawatts(0.023)
+val sum = load1 + load2
+sum == Kilowatts(35)
+sum == Megawatts(0.035) // comparisions automatically convert scale
 ```
 
 The above sample works because Kilowatts and Megawatts are both units of Power.  Only the scale is
 different and the library applies an appropriate conversion.  Also, notice that keeping track of
 the scale within the value name is no longer needed:
 
-```scala
-scala> import squants.energy.{Energy, Power, Kilowatts, KilowattHours}
+```tut
 import squants.energy.{Energy, Power, Kilowatts, KilowattHours}
-
-scala> val load: Power = Kilowatts(1.2)
-load: squants.energy.Power = 1.2 kW
-
-scala> val energy: Energy = KilowattHours(23.0)
-energy: squants.energy.Energy = 23.0 kWh
+val load: Power = Kilowatts(1.2)
+val energy: Energy = KilowattHours(23.0)
 ```
 
 Invalid operations, like adding power and energy, no longer compile:
-```scala
-scala> val sum = load + energy
-<console>:13: error: type mismatch;
- found   : squants.energy.Energy
- required: squants.energy.Power
-       val sum = load + energy
-                        ^
+```tut:fail
+val sum = load + energy
 ```
 By using stronger types, we catch the error earlier in the development cycle, preventing the error made when using Double in the example above.
 
@@ -154,7 +128,7 @@ Dimensionally correct type conversions are a key feature of Squants.
 Conversions are implemented by defining relationships between Quantity types using the `*` and `/` operators.
 
 Code samples in this section assume these imports:
-```scala
+```tut:silent:reset
 import squants.energy.{Kilowatts, Power}
 import squants.time.{Hours, Days}
 ```
@@ -162,35 +136,28 @@ import squants.time.{Hours, Days}
 The following code demonstrates creating ratio between two quantities of the same dimension,
 resulting in a dimensionless value:
 
-```scala
-scala> val ratio = Days(1) / Hours(3)
-ratio: Double = 8.0
+```tut
+val ratio = Days(1) / Hours(3)
 ```
 
 This code demonstrates use of the `Power.*` method that takes a `Time` and returns an `Energy`:
 
-```scala
-scala> val load = Kilowatts(1.2)
-load: squants.energy.Power = 1.2 kW
-
-scala> val time = Hours(2)
-time: squants.time.Time = 2.0 h
-
-scala> val energyUsed = load * time
-energyUsed: squants.energy.Energy = 2400.0 Wh
+```tut
+val load = Kilowatts(1.2)
+val time = Hours(2)
+val energyUsed = load * time
 ```
 
 This code demonstrates use of the `Energy./` method that takes a `Time` and returns a `Power`:
 
-```scala
-scala> val aveLoad: Power = energyUsed / time
-aveLoad: squants.energy.Power = 1200.0 W
+```tut
+val aveLoad: Power = energyUsed / time
 ```
 
 ### Unit Conversions
 
 Code samples in this section assume these imports:
-```scala
+```tut:silent:reset
 import scala.language.postfixOps
 import squants.energy.{Gigawatts, Kilowatts, Power, Megawatts}
 import squants.mass.MassConversions._
@@ -201,12 +168,9 @@ import squants.thermal.Fahrenheit
 
 Quantity values are based in the units used to create them.
 
-```scala
-scala> val loadA: Power = Kilowatts(1200)
-loadA: squants.energy.Power = 1200.0 kW
-
-scala> val loadB: Power = Megawatts(1200)
-loadB: squants.energy.Power = 1200.0 MW
+```tut
+val loadA: Power = Kilowatts(1200)
+val loadB: Power = Megawatts(1200)
 ```
 
 Since Squants properly equates values of a like dimension, regardless of the unit,
@@ -217,15 +181,10 @@ However, there are times when you may need to set a Quantity value to a specific
 
 When necessary, a quantity can be converted to another unit using the `in` method.
 
-```scala
-scala> val loadA = Kilowatts(1200)
-loadA: squants.energy.Power = 1200.0 kW
-
-scala> val loadB = loadA in Megawatts
-loadB: squants.energy.Power = 1.2 MW
-
-scala> val loadC = loadA in Gigawatts
-loadC: squants.energy.Power = 0.0012 GW
+```tut
+val loadA = Kilowatts(1200)
+val loadB = loadA in Megawatts
+val loadC = loadA in Gigawatts
 ```
 
 Sometimes you need to get the numeric value of the quantity in a specific unit
@@ -234,31 +193,19 @@ or to perform analysis beyond Squant's domain)
 
 When necessary, the value can be extracted in the desired unit with the `to` method.
 
-```scala
-scala> val load: Power = Kilowatts(1200)
-load: squants.energy.Power = 1200.0 kW
-
-scala> val kw: Double = load to Kilowatts
-kw: Double = 1200.0
-
-scala> val mw: Double = load to Megawatts
-mw: Double = 1.2
-
-scala> val gw: Double = load to Gigawatts
-gw: Double = 0.0012
+```tut
+val load: Power = Kilowatts(1200)
+val kw: Double = load to Kilowatts
+val mw: Double = load to Megawatts
+val gw: Double = load to Gigawatts
 ```
 
 Most types include methods with convenient aliases for the `to` methods.
 
-```scala
-scala> val kw: Double = load toKilowatts
-kw: Double = 1200.0
-
-scala> val mw: Double = load toMegawatts
-mw: Double = 1.2
-
-scala> val gw: Double = load toGigawatts
-gw: Double = 0.0012
+```tut
+val kw: Double = load toKilowatts
+val mw: Double = load toMegawatts
+val gw: Double = load toGigawatts
 ```
 
 NOTE - It is important to use the `to` method for extracting the numeric value,
@@ -268,31 +215,19 @@ To prevent improper usage, direct access to the `Quantity.value` field may be de
 
 Creating strings formatted in the desired unit:
 
-```scala
-scala> val kw: String = load toString Kilowatts
-kw: String = 1200.0 kW
-
-scala> val mw: String = load toString Megawatts
-mw: String = 1.2 MW
-
-scala> val gw: String = load toString Gigawatts
-gw: String = 0.0012 GW
+```tut
+val kw: String = load toString Kilowatts
+val mw: String = load toString Megawatts
+val gw: String = load toString Gigawatts
 ```
 
 Creating `Tuple2[Double, String]` that includes a numeric value and unit symbol:
 
-```scala
-scala> val load: Power = Kilowatts(1200)
-load: squants.energy.Power = 1200.0 kW
-
-scala> val kw = load toTuple
-kw: (Double, String) = (1200.0,kW)
-
-scala> val mw = load toTuple Megawatts
-mw: (Double, String) = (1.2,MW)
-
-scala> val gw = load toTuple Gigawatts
-gw: (Double, String) = (0.0012,GW)
+```tut
+val load: Power = Kilowatts(1200)
+val kw = load toTuple
+val mw = load toTuple Megawatts
+val gw = load toTuple Gigawatts
 ```
 
 This can be useful for passing properly scaled quantities to other processes
@@ -300,35 +235,24 @@ that do not use Squants, or require use of more basic types (Double, String)
 
 Simple console based conversions (using DSL described below)
 
-```scala
-scala> 1.kilograms to Pounds
-res0: Double = 2.2046226218487757
+```tut
+1.kilograms to Pounds
+kilogram / pound
 
-scala> kilogram / pound
-res1: Double = 2.2046226218487757
+2.1.pounds to Kilograms
+2.1.pounds / kilogram
 
-scala> 2.1.pounds to Kilograms
-res2: Double = 0.952543977
-
-scala> 2.1.pounds / kilogram
-res3: Double = 0.9525439770000002
-
-scala> 100.C to Fahrenheit
-res4: Double = 212.0
+100.C to Fahrenheit
 ```
 
 ### Mapping over Quantity values
 Apply a `Double => Double` operation to the underlying value of a quantity, while preserving its type and unit.
 
-```scala
-scala> import squants.energy.Kilowatts
+```tut:reset
 import squants.energy.Kilowatts
 
-scala> val load = Kilowatts(2.0)
-load: squants.energy.Power = 2.0 kW
-
-scala> val newLoad = load.map(v => v * 2 + 10)
-newLoad: squants.energy.Power = 14.0 kW
+val load = Kilowatts(2.0)
+val newLoad = load.map(v => v * 2 + 10)
 ```
 
 The `q.map(f)` method effectively expands to `q.unit(f(q.to(q.unit))`
@@ -337,31 +261,20 @@ The `q.map(f)` method effectively expands to `q.unit(f(q.to(q.unit))`
 Create an implicit Quantity value to be used as a tolerance in approximations.
 Then use the `approx` method (or `=~`, `~=`, `≈` operators) like you would use the `equals` method (`==` operator).
 
-```scala
-scala> import squants.energy.{Kilowatts, Watts}
+```tut:reset
 import squants.energy.{Kilowatts, Watts}
 
-scala> val load = Kilowatts(2.0)
-load: squants.energy.Power = 2.0 kW
-
-scala> val reading = Kilowatts(1.9999)
-reading: squants.energy.Power = 1.9999 kW
+val load = Kilowatts(2.0)
+val reading = Kilowatts(1.9999)
 ```
 
 Calls to `approx` (and its symbolic aliases) use an implicit tolerance:
 
-```scala
-scala> implicit val tolerance = Watts(.1)
-tolerance: squants.energy.Power = 0.1 W
-
-scala> load =~ reading 
-res0: Boolean = true
-
-scala> load ≈ reading 
-res1: Boolean = true
-
-scala> load approx reading
-res2: Boolean = true
+```tut
+implicit val tolerance = Watts(.1)
+load =~ reading 
+load ≈ reading 
+load approx reading
 ```
 
 The `=~` and `≈` are the preferred operators as they have the correct precedence for equality operations.
@@ -380,53 +293,29 @@ The SVector object is a factory for creating DoubleVectors and QuantityVectors.
 The dimensionality of the vector is determined by the number of arguments.
 Most basic vector operations are currently supported (addition, subtraction, scaling, cross and dot products)
 
-```scala
-scala> import squants.{QuantityVector, SVector}
+```tut:reset
 import squants.{QuantityVector, SVector}
-
-scala> import squants.space.{Kilometers, Length}
 import squants.space.{Kilometers, Length}
-
-scala> import squants.space.LengthConversions._
 import squants.space.LengthConversions._
 
-scala> val vector: QuantityVector[Length] = SVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
-vector: squants.QuantityVector[squants.space.Length] = QuantityVector(WrappedArray(1.2 km, 4.3 km, 2.3 km))
+val vector: QuantityVector[Length] = SVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
+val magnitude: Length = vector.magnitude        // returns the scalar value of the vector
+val normalized = vector.normalize(Kilometers)   // returns a corresponding vector scaled to 1 of the given unit
 
-scala> val magnitude: Length = vector.magnitude        // returns the scalar value of the vector
-magnitude: squants.space.Length = 5.021951811795888 km
+val vector2: QuantityVector[Length] = SVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
+val vectorSum = vector + vector2        // returns the sum of two vectors
+val vectorDiff = vector - vector2       // return the difference of two vectors
+val vectorScaled = vector * 5           // returns vector scaled 5 times
+val vectorReduced = vector / 5          // returns vector reduced 5 time
+val vectorDouble = vector / 5.meters    // returns vector reduced and converted to DoubleVector
+val dotProduct = vector * vectorDouble  // returns the Dot Product of vector and vectorDouble
 
-scala> val normalized = vector.normalize(Kilometers)   // returns a corresponding vector scaled to 1 of the given unit
-normalized: vector.SVectorType = QuantityVector(ArrayBuffer(0.2389509188800581 km, 0.8562407926535415 km, 0.45798926118677796 km))
-
-scala> val vector2: QuantityVector[Length] = SVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
-vector2: squants.QuantityVector[squants.space.Length] = QuantityVector(WrappedArray(1.2 km, 4.3 km, 2.3 km))
-
-scala> val vectorSum = vector + vector2        // returns the sum of two vectors
-vectorSum: vector.SVectorType = QuantityVector(ArrayBuffer(2.4 km, 8.6 km, 4.6 km))
-
-scala> val vectorDiff = vector - vector2       // return the difference of two vectors
-vectorDiff: vector.SVectorType = QuantityVector(ArrayBuffer(0.0 km, 0.0 km, 0.0 km))
-
-scala> val vectorScaled = vector * 5           // returns vector scaled 5 times
-vectorScaled: vector.SVectorType = QuantityVector(ArrayBuffer(6.0 km, 21.5 km, 11.5 km))
-
-scala> val vectorReduced = vector / 5          // returns vector reduced 5 time
-vectorReduced: vector.SVectorType = QuantityVector(ArrayBuffer(0.24 km, 0.86 km, 0.45999999999999996 km))
-
-scala> val vectorDouble = vector / 5.meters    // returns vector reduced and converted to DoubleVector
-vectorDouble: squants.DoubleVector = DoubleVector(ArrayBuffer(240.0, 860.0, 459.99999999999994))
-
-scala> val dotProduct = vector * vectorDouble  // returns the Dot Product of vector and vectorDouble
-dotProduct: squants.space.Length = 5044.0 km
-
-scala> val crossProduct = vector crossProduct vectorDouble  // currently only supported for 3-dimensional vectors
-crossProduct: vector.SVectorType = QuantityVector(WrappedArray(0.0 km, 1.1368683772161603E-13 km, 0.0 km))
+val crossProduct = vector crossProduct vectorDouble  // currently only supported for 3-dimensional vectors
 ```
 
 Simple non-quantity (Double based) vectors are also supported.
 
-```scala
+```tut:silent
 import squants.DoubleVector
 
 val vector: DoubleVector = SVector(1.2, 4.3, 2.3, 5.4)   // a Four-dimensional vector
@@ -436,46 +325,26 @@ val vector: DoubleVector = SVector(1.2, 4.3, 2.3, 5.4)   // a Four-dimensional v
 
 Currently dimensional conversions are supported by using the slightly verbose, but flexible map method.
 
-```scala
-scala> import squants.{DoubleVector, QuantityVector}
+```tut:reset
 import squants.{DoubleVector, QuantityVector}
-
-scala> import squants.motion.Velocity
 import squants.motion.Velocity
-
-scala> import squants.space.{Area, Kilometers, Length, Meters}
 import squants.space.{Area, Kilometers, Length, Meters}
-
-scala> import squants.time.Seconds
 import squants.time.Seconds
 
-scala> val vectorLength = QuantityVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
-vectorLength: squants.QuantityVector[squants.space.Length] = QuantityVector(WrappedArray(1.2 km, 4.3 km, 2.3 km))
+val vectorLength = QuantityVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
+val vectorArea = vectorLength.map[Area](_ * Kilometers(2))      // QuantityVector(2.4 km², 8.6 km², 4.6 km²)
+val vectorVelocity = vectorLength.map[Velocity](_ / Seconds(1)) // QuantityVector(1200.0 m/s, 4300.0 m/s, 2300.0 m/s)
 
-scala> val vectorArea = vectorLength.map[Area](_ * Kilometers(2))      // QuantityVector(2.4 km², 8.6 km², 4.6 km²)
-vectorArea: squants.QuantityVector[squants.space.Area] = QuantityVector(ArrayBuffer(2.4 km², 8.6 km², 4.6 km²))
-
-scala> val vectorVelocity = vectorLength.map[Velocity](_ / Seconds(1)) // QuantityVector(1200.0 m/s, 4300.0 m/s, 2300.0 m/s)
-vectorVelocity: squants.QuantityVector[squants.motion.Velocity] = QuantityVector(ArrayBuffer(1200.0 m/s, 4300.0 m/s, 2300.0 m/s))
-
-scala> val vectorDouble = DoubleVector(1.2, 4.3, 2.3)
-vectorDouble: squants.DoubleVector = DoubleVector(WrappedArray(1.2, 4.3, 2.3))
-
-scala> val vectorLength = vectorDouble.map[Length](Kilometers(_))      // QuantityVector(1.2 km, 4.3 km, 2.3 km)
-vectorLength: squants.QuantityVector[squants.space.Length] = QuantityVector(ArrayBuffer(1.2 km, 4.3 km, 2.3 km))
+val vectorDouble = DoubleVector(1.2, 4.3, 2.3)
+val vectorLength = vectorDouble.map[Length](Kilometers(_))      // QuantityVector(1.2 km, 4.3 km, 2.3 km)
 ```
 
 Convert QuantityVectors to specific units using the `to` or `in` method - much like Quantities.
 
-```scala
-scala> val vectorLength = QuantityVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
-vectorLength: squants.QuantityVector[squants.space.Length] = QuantityVector(WrappedArray(1.2 km, 4.3 km, 2.3 km))
-
-scala> val vectorMetersNum = vectorLength.to(Meters)   // DoubleVector(1200.0, 4300.0, 2300.0)
-vectorMetersNum: squants.DoubleVector = DoubleVector(ArrayBuffer(1200.0, 4300.0, 2300.0))
-
-scala> val vectorMeters = vectorLength.in(Meters)      // QuantityVector(1200.0 m, 4300.0 m, 2300.0 m)
-vectorMeters: squants.QuantityVector[squants.space.Length] = QuantityVector(ArrayBuffer(1200.0 m, 4300.0 m, 2300.0 m))
+```tut
+val vectorLength = QuantityVector(Kilometers(1.2), Kilometers(4.3), Kilometers(2.3))
+val vectorMetersNum = vectorLength.to(Meters)   // DoubleVector(1200.0, 4300.0, 2300.0)
+val vectorMeters = vectorLength.in(Meters)      // QuantityVector(1200.0 m, 4300.0 m, 2300.0 m)
 ```
 
 ## Market Package
@@ -488,21 +357,13 @@ many of the behaviors have been overridden and augmented to realize correct beha
 A Quantity of purchasing power measured in Currency units.
 Like other quantities, the Unit of Measures are used to create Money values.
 
-```scala
-scala> import squants.market.{BTC, JPY, USD, XAU}
+```tut:reset
 import squants.market.{BTC, JPY, USD, XAU}
 
-scala> val tenBucks = USD(10)      // Money: 10 USD
-tenBucks: squants.market.Money = 10.00 USD
-
-scala> val someYen = JPY(1200)     // Money: 1200 JPY
-someYen: squants.market.Money = 1200 JPY
-
-scala> val goldStash = XAU(50)     // Money: 50 XAU
-goldStash: squants.market.Money = 50.0000 XAU
-
-scala> val digitalCache = BTC(50)  // Money: 50 BTC
-digitalCache: squants.market.Money = 50.000000000000000 BTC
+val tenBucks = USD(10)      // Money: 10 USD
+val someYen = JPY(1200)     // Money: 1200 JPY
+val goldStash = XAU(50)     // Money: 50 XAU
+val digitalCache = BTC(50)  // Money: 50 BTC
 ```
 
 ### Price
@@ -512,7 +373,7 @@ A Price value is typed on a Quantity and can be denominated in any defined Curre
 *Price = Money / Quantity*
 
 Assuming these imports:
-```scala
+```tut:reset:silent
 import squants.{Dozen, Each}
 import squants.energy.MegawattHours
 import squants.market.USD
@@ -520,73 +381,46 @@ import squants.space.UsGallons
 ```
 
 You can compute the following:
-```scala
-scala> val threeForADollar = USD(1) / Each(3)
-threeForADollar: squants.market.Price[squants.Dimensionless] = 1.00 USD/3.0 ea
+```tut
+val threeForADollar = USD(1) / Each(3)
+val energyPrice = USD(102.20) / MegawattHours(1)
+val milkPrice = USD(4) / UsGallons(1)
 
-scala> val energyPrice = USD(102.20) / MegawattHours(1)
-energyPrice: squants.market.Price[squants.energy.Energy] = 102.20 USD/1.0 MWh
-
-scala> val milkPrice = USD(4) / UsGallons(1)
-milkPrice: squants.market.Price[squants.space.Volume] = 4.00 USD/1.0 gal
-
-scala> val costForABunch = threeForADollar * Dozen(10)
-costForABunch: squants.market.Money = 40.00 USD
-
-scala> val energyCost = energyPrice * MegawattHours(4)
-energyCost: squants.market.Money = 408.80 USD
-
-scala> val milkQuota = USD(20) / milkPrice
-milkQuota: squants.space.Volume = 5.0 gal
+val costForABunch = threeForADollar * Dozen(10)
+val energyCost = energyPrice * MegawattHours(4)
+val milkQuota = USD(20) / milkPrice
 ```
 
 ### FX Support
 Currency Exchange Rates are used to define the conversion factors between currencies
 
-```scala
-scala> import squants.market.{CurrencyExchangeRate, JPY, Money, USD}
+```tut:reset
 import squants.market.{CurrencyExchangeRate, JPY, Money, USD}
 
-scala> // create an exchange rate
-     | val rate1 = CurrencyExchangeRate(USD(1), JPY(100))
-rate1: squants.market.CurrencyExchangeRate = USD/JPY 100.0
+// create an exchange rate
+val rate1 = CurrencyExchangeRate(USD(1), JPY(100))
+// OR
+val rate2 = USD / JPY(100)
+// OR
+val rate3 = JPY(100) -> USD(1)
+// OR
+val rate4 = JPY(100) toThe USD(1)
 
-scala> // OR
-     | val rate2 = USD / JPY(100)
-rate2: squants.market.CurrencyExchangeRate = USD/JPY 100.0
-
-scala> // OR
-     | val rate3 = JPY(100) -> USD(1)
-rate3: squants.market.CurrencyExchangeRate = USD/JPY 100.0
-
-scala> // OR
-     | val rate4 = JPY(100) toThe USD(1)
-rate4: squants.market.CurrencyExchangeRate = USD/JPY 100.0
-
-scala> val someYen: Money = JPY(350)
-someYen: squants.market.Money = 350 JPY
-
-scala> val someBucks: Money = USD(23.50)
-someBucks: squants.market.Money = 23.50 USD
+val someYen: Money = JPY(350)
+val someBucks: Money = USD(23.50)
 ```
 
 Use the `convert` method which automatically converts the money to the 'other' currency:
 
-```scala
-scala> val dollarAmount: Money = rate1.convert(someYen)
-dollarAmount: squants.market.Money = 3.50 USD
-
-scala> val yenAmount: Money = rate1.convert(someBucks)
-yenAmount: squants.market.Money = 2350 JPY
+```tut
+val dollarAmount: Money = rate1.convert(someYen)
+val yenAmount: Money = rate1.convert(someBucks)
 ```
 
 Or just use the `*` operator in either direction (money * rate, or rate * money):
-```scala
-scala> val dollarAmount2: Money = rate1 * someYen
-dollarAmount2: squants.market.Money = 3.50 USD
-
-scala> val yenAmount2: Money = someBucks * rate1
-yenAmount2: squants.market.Money = 2350 JPY
+```tut`
+val dollarAmount2: Money = rate1 * someYen
+val yenAmount2: Money = someBucks * rate1
 ```
 
 ### Money Context
@@ -596,62 +430,40 @@ It also provides support for updating exchange rates and using those rates for a
 The technique and frequency chosen for exchange rate updates is completely in control of the application.
 
 Assuming these imports:
-```scala
+```tut:silent
 import squants.energy.MegawattHours
 import squants.market.{CAD, JPY, MXN, USD}
 import squants.market.defaultMoneyContext
 ```
 
 You can compute:
-```scala
-scala> val exchangeRates = List(USD / CAD(1.05), USD / MXN(12.50), USD / JPY(100))
-exchangeRates: List[squants.market.CurrencyExchangeRate] = List(USD/CAD 1.05, USD/MXN 12.5, USD/JPY 100.0)
+```tut
+val exchangeRates = List(USD / CAD(1.05), USD / MXN(12.50), USD / JPY(100))
+implicit val moneyContext = defaultMoneyContext withExchangeRates exchangeRates
 
-scala> implicit val moneyContext = defaultMoneyContext withExchangeRates exchangeRates
-moneyContext: squants.market.MoneyContext = MoneyContext(squants.market.USD$@2282d3a2,Set(squants.market.NOK$@6460f2b0, squants.market.RUB$@7aab2eb2, squants.market.AUD$@2fc4ea38, squants.market.MXN$@54c5d920, squants.market.MYR$@2f1833f8, squants.market.CAD$@68c0f7c5, squants.market.NZD$@ddfb50, squants.market.CLP$@51b13827, squants.market.CNY$@54de2050, squants.market.XAG$@77d4c0b6, squants.market.XAU$@183cb267, squants.market.USD$@2282d3a2, squants.market.EUR$@5e162c54, squants.market.KRW$@26384c20, squants.market.GBP$@7bef4b66, squants.market.CHF$@592c9c10, squants.market.INR$@48167606, squants.market.JPY$@270d97dc, squants.market.SEK$@14c255ec, squants.market.HKD$@3c39d6d9, squants.market.CZK$@3b4f9bd1, squants.market.BTC$@3bc1c16c, squants.market.DKK$@63e4cb4, squants.market.BRL$@...
-
-scala> val energyPrice = USD(102.20) / MegawattHours(1)
-energyPrice: squants.market.Price[squants.energy.Energy] = 102.20 USD/1.0 MWh
-
-scala> val someMoney = Money(350) // 350 in the default Cur
-someMoney: squants.market.Money = 350.00 USD
-
-scala> val usdMoney: Money = someMoney in USD
-usdMoney: squants.market.Money = 350.00 USD
-
-scala> val usdBigDecimal: BigDecimal = someMoney to USD
-usdBigDecimal: BigDecimal = 350.0
-
-scala> val yenCost: Money = (energyPrice * MegawattHours(5)) in JPY
-yenCost: squants.market.Money = 51100 JPY
-
-scala> val northAmericanSales: Money = (CAD(275) + USD(350) + MXN(290)) in USD
-northAmericanSales: squants.market.Money = 635.10 USD
+val energyPrice = USD(102.20) / MegawattHours(1)
+val someMoney = Money(350) // 350 in the default Cur
+val usdMoney: Money = someMoney in USD
+val usdBigDecimal: BigDecimal = someMoney to USD
+val yenCost: Money = (energyPrice * MegawattHours(5)) in JPY
+val northAmericanSales: Money = (CAD(275) + USD(350) + MXN(290)) in USD
 ```
 
 ## Quantity Ranges
 Used to represent a range of Quantity values between an upper and lower bound
 
-```scala
-scala> import squants.QuantityRange
+```tut:reset
 import squants.QuantityRange
-
-scala> import squants.energy.{Kilowatts, Power}
 import squants.energy.{Kilowatts, Power}
 
-scala> val load1: Power = Kilowatts(1000)
-load1: squants.energy.Power = 1000.0 kW
-
-scala> val load2: Power = Kilowatts(5000)
-load2: squants.energy.Power = 5000.0 kW
-
-scala> val range: QuantityRange[Power] = QuantityRange(load1, load2)
-range: squants.QuantityRange[squants.energy.Power] = QuantityRange(1000.0 kW,5000.0 kW)
+val load1: Power = Kilowatts(1000)
+val load2: Power = Kilowatts(5000)
+val range: QuantityRange[Power] = QuantityRange(load1, load2)
 ```
 
 Use multiplication and division to create a Seq of ranges from the original
 
-```scala
+```tut:silent
 // Create a Seq of 10 sequential ranges starting with the original and each the same size as the original
 val rs1 = range * 10
 // Create a Seq of 10 sequential ranges each 1/10th of the original size
@@ -661,7 +473,7 @@ val rs3 = range / Kilowatts(400)
 ```
 Apply foreach, map and foldLeft/foldRight directly to QuantityRanges with a divisor
 
-```scala
+```tut:silent:fail
 // foreach over each of the 400 kilometer ranges within the range
 range.foreach(Kilometers(400)) {r => ???}
 // map over each of 10 even parts of the range
@@ -686,7 +498,7 @@ Implicit conversions give the DSL some features that allows user code to express
 more naturally expressive and readable way.
 
 Code samples in this section assume these imports
-```scala
+```tut:silent:reset
 import squants.energy.{Kilowatts, MegawattHours, Power}
 import squants.market.{Price, USD}
 import squants.time.Hours
@@ -694,23 +506,16 @@ import squants.time.Hours
 
 Create Quantities using Unit Of Measure Factory objects (no implicits required):
 
-```scala
-scala> val load = Kilowatts(100)
-load: squants.energy.Power = 100.0 kW
-
-scala> val time = Hours(3.75)
-time: squants.time.Time = 3.75 h
-
-scala> val money = USD(112.50)
-money: squants.market.Money = 112.50 USD
-
-scala> val price = Price(money, MegawattHours(1))
-price: squants.market.Price[squants.energy.Energy] = 112.50 USD/1.0 MWh
+```tut
+val load = Kilowatts(100)
+val time = Hours(3.75)
+val money = USD(112.50)
+val price = Price(money, MegawattHours(1))
 ```
 
 Create Quantities using Unit of Measure names and/or symbols (uses implicits):
 
-```scala
+```tut:silent
 import scala.language.postfixOps
 import squants.energy.EnergyConversions._
 import squants.energy.PowerConversions._
@@ -719,75 +524,54 @@ import squants.market.MoneyConversions._
 import squants.space.LengthConversions._
 import squants.time.TimeConversions._
 ```
-```scala
-scala> val load1 = 100 kW 			        // Simple expressions don’t need dots
-load1: squants.energy.Power = 100.0 kW
-
-scala> val load2 = 100 megawatts
-load2: squants.energy.Power = 100.0 MW
-
-scala> val time = 3.hours + 45.minutes     // Compound expressions may need dots
-time: squants.time.Time = 3.75 h
+```tut
+val load1 = 100 kW 			        // Simple expressions don’t need dots
+val load2 = 100 megawatts
+val time = 3.hours + 45.minutes     // Compound expressions may need dots
 ```
 
 Create Quantities using operations between other Quantities:
 
-```scala
-scala> val energyUsed = 100.kilowatts * (3.hours + 45.minutes)
-energyUsed: squants.energy.Energy = 375000.0 Wh
-
-scala> val price = 112.50.USD / 1.megawattHours
-price: squants.market.Price[squants.energy.Energy] = 112.50 USD/1.0 MWh
-
-scala> val speed = 55.miles / 1.hours
-speed: squants.motion.Velocity = 24.587249174399997 m/s
+```tut
+val energyUsed = 100.kilowatts * (3.hours + 45.minutes)
+val price = 112.50.USD / 1.megawattHours
+val speed = 55.miles / 1.hours
 ```
 
 Create Quantities using formatted Strings:
 
-```scala
-scala> val load = Power("40 MW")
-load: scala.util.Try[squants.energy.Power] = Success(40.0 MW)
+```tut
+val load = Power("40 MW")
 ```
 
 Create Quantities using Tuples:
 
-```scala
-scala> val load = Power((40.5, "MW"))
-load: scala.util.Try[squants.energy.Power] = Success(40.5 MW)
+```tut
+val load = Power((40.5, "MW"))
 ```
 
 Use single unit values to simplify expressions:
 
-```scala
-scala> // Hours(1) == 1.hours == hour
-     | val ramp = 100.kilowatts / hour
-ramp: squants.energy.PowerRamp = 100000.0 W/h
+```tut
+// Hours(1) == 1.hours == hour
+val ramp = 100.kilowatts / hour
+val speed = 100.kilometers / hour
 
-scala> val speed = 100.kilometers / hour
-speed: squants.motion.Velocity = 27.77777777777778 m/s
-
-scala> // MegawattHours(1) == 1.megawattHours == megawattHour == MWh
-     | val hi = 100.dollars / MWh
-hi: squants.market.Price[squants.energy.Energy] = 100.00 USD/1.0 MWh
-
-scala> val low = 40.dollars / megawattHour
-low: squants.market.Price[squants.energy.Energy] = 40.00 USD/1.0 MWh
+// MegawattHours(1) == 1.megawattHours == megawattHour == MWh
+val hi = 100.dollars / MWh
+val low = 40.dollars / megawattHour
 ```
 
 Implicit conversion support for using Double on the left side of multiplication:
 
-```scala
-scala> val load = 10 * 4.MW
-load: squants.energy.Power = 40.0 MW
-
-scala> val driveArrayCapacity = 12 * 600.gb
-driveArrayCapacity: squants.information.Information = 7200.0 GB
+```tut
+val load = 10 * 4.MW
+val driveArrayCapacity = 12 * 600.gb
 ```
 
 Create Quantity Ranges using `to` or `plusOrMinus` (`+-`) operators:
 
-```scala
+```tut:silent
 val range1 = 1000.kW to 5000.kW	             // 1000.kW to 5000.kW
 val range2 = 5000.kW plusOrMinus 1000.kW     // 4000.kW to 6000.kW
 val range2 = 5000.kW +- 1000.kW              // 4000.kW to 6000.kW
@@ -797,15 +581,11 @@ val range2 = 5000.kW +- 1000.kW              // 4000.kW to 6000.kW
 Most Quantities that support implicit conversions also include an implicit Numeric object that can be imported
 to your code where Numeric support is required.  These follow the following pattern:
 
-```scala
-scala> import squants.mass.{Grams, Kilograms} 
-import squants.mass.{Grams, Kilograms}
-
-scala> import squants.mass.MassConversions.MassNumeric
+```tut:reset
+import squants.mass.{Grams, Kilograms} 
 import squants.mass.MassConversions.MassNumeric
 
-scala> val sum = List(Kilograms(100), Grams(34510)).sum
-sum: squants.mass.Mass = 134510.0 g
+val sum = List(Kilograms(100), Grams(34510)).sum
 ```
 
 NOTE - Because a quantity can not be multiplied by a like quantity and return a like quantity, the `Numeric.times`
@@ -820,19 +600,17 @@ in a few important ways.
 
 The following code provides a basic example for creating a MoneyNumeric:
 
-```scala
+```tut:reset:silent
 import squants.market.defaultMoneyContext
 import squants.market.MoneyConversions._
 import squants.market.USD
 implicit val moneyContext = defaultMoneyContext
 ```
 
-```scala
-scala> implicit val moneyNum = new MoneyNumeric()
-moneyNum: squants.market.MoneyConversions.MoneyNumeric = squants.market.MoneyConversions$MoneyNumeric@3702b889
+```tut
+implicit val moneyNum = new MoneyNumeric()
 
-scala> val sum = List(USD(100), USD(10)).sum
-sum: squants.market.Money = 110.00 USD
+val sum = List(USD(100), USD(10)).sum
 ```
 
 ## Type Hierarchy
@@ -900,7 +678,7 @@ These traits provide operations with time operands which result in correct dimen
 
 
 Using these imports:
-```scala
+```tut:reset:silent
 import squants.energy.Kilowatts
 import squants.motion.{Acceleration, Velocity}
 import squants.space.{Kilometers, Length}
@@ -910,36 +688,21 @@ import squants.time.TimeConversions._
 ```
 
 You can code the following:
-```scala
-scala> val distance: Length = Kilometers(100)
-distance: squants.space.Length = 100.0 km
+```tut
+val distance: Length = Kilometers(100)
+val time: Time = Hours(2)
+val velocity: Velocity = distance / time
+val acc: Acceleration = velocity / Seconds(1)
 
-scala> val time: Time = Hours(2)
-time: squants.time.Time = 2.0 h
-
-scala> val velocity: Velocity = distance / time
-velocity: squants.motion.Velocity = 13.88888888888889 m/s
-
-scala> val acc: Acceleration = velocity / Seconds(1)
-acc: squants.motion.Acceleration = 13.88888888888889 m/s²
-
-scala> val gravity = 32.feet / second.squared
-gravity: squants.Acceleration = 9.7536195072 m/s²
+val gravity = 32.feet / second.squared
 ```
 
 Power is the 1st Time Derivative of Energy, PowerRamp is the 2nd.
-```scala
-scala> val power = Kilowatts(100)
-power: squants.energy.Power = 100.0 kW
-
-scala> val time: Time = Hours(2)
-time: squants.time.Time = 2.0 h
-
-scala> val energy = power * time
-energy: squants.energy.Energy = 200000.0 Wh
-
-scala> val ramp = Kilowatts(50) / Hours(1)
-ramp: squants.energy.PowerRamp = 50000.0 W/h
+```tut
+val power = Kilowatts(100)
+val time: Time = Hours(2)
+val energy = power * time
+val ramp = Kilowatts(50) / Hours(1)
 ```
 
 ## Use Cases
@@ -950,7 +713,7 @@ The primary use case for Squants, as described above, is to produce code that is
 that perform dimensional analysis.
 
 This code samples in this section use these imports:
-```scala
+```tut:reset:silent
 import squants.energy.Energy
 import squants.energy.EnergyConversions._
 import squants.energy.PowerConversions._
@@ -967,46 +730,27 @@ import squants.time.Time
 import squants.time.TimeConversions._
 ```
 
-```scala
-scala> implicit val moneyContext = defaultMoneyContext
-moneyContext: squants.market.MoneyContext = MoneyContext(squants.market.USD$@2282d3a2,Set(squants.market.NOK$@6460f2b0, squants.market.RUB$@7aab2eb2, squants.market.AUD$@2fc4ea38, squants.market.MXN$@54c5d920, squants.market.MYR$@2f1833f8, squants.market.CAD$@68c0f7c5, squants.market.NZD$@ddfb50, squants.market.CLP$@51b13827, squants.market.CNY$@54de2050, squants.market.XAG$@77d4c0b6, squants.market.XAU$@183cb267, squants.market.USD$@2282d3a2, squants.market.EUR$@5e162c54, squants.market.KRW$@26384c20, squants.market.GBP$@7bef4b66, squants.market.CHF$@592c9c10, squants.market.INR$@48167606, squants.market.JPY$@270d97dc, squants.market.SEK$@14c255ec, squants.market.HKD$@3c39d6d9, squants.market.CZK$@3b4f9bd1, squants.market.BTC$@3bc1c16c, squants.market.DKK$@63e4cb4, squants.market.BRL$@...
+```tut
+implicit val moneyContext = defaultMoneyContext
+val energyPrice: Price[Energy] = 45.25.money / megawattHour
+val energyUsage: Energy = 345.kilowatts * 5.4.hours
+val energyCost: Money = energyPrice * energyUsage
 
-scala> val energyPrice: Price[Energy] = 45.25.money / megawattHour
-energyPrice: squants.market.Price[squants.energy.Energy] = 45.25 USD/1.0 MWh
+val dodgeViper: Acceleration = 60.miles / hour / 3.9.seconds
+val speedAfter5Seconds: Velocity = dodgeViper * 5.seconds
+val timeTo100MPH: Time = 100.miles / hour / dodgeViper
 
-scala> val energyUsage: Energy = 345.kilowatts * 5.4.hours
-energyUsage: squants.energy.Energy = 1863000.0000000002 Wh
-
-scala> val energyCost: Money = energyPrice * energyUsage
-energyCost: squants.market.Money = 84.30 USD
-
-scala> val dodgeViper: Acceleration = 60.miles / hour / 3.9.seconds
-dodgeViper: squants.motion.Acceleration = 6.877552216615386 m/s²
-
-scala> val speedAfter5Seconds: Velocity = dodgeViper * 5.seconds
-speedAfter5Seconds: squants.motion.Velocity = 34.38776108307693 m/s
-
-scala> val timeTo100MPH: Time = 100.miles / hour / dodgeViper
-timeTo100MPH: squants.time.Time = 6.499999999999999 s
-
-scala> val density: Density = 1200.kilograms / cubicMeter
-density: squants.mass.Density = 1200.0 kg/m³
-
-scala> val volFlowRate: VolumeFlow = 10.gallons / minute
-volFlowRate: squants.motion.VolumeFlow = 6.30901964E-4 m³/s
-
-scala> val flowTime: Time = 30.minutes
-flowTime: squants.time.Time = 30.0 m
-
-scala> val totalMassFlow: Mass = volFlowRate * flowTime * density
-totalMassFlow: squants.mass.Mass = 1362.7482422399999 kg
+val density: Density = 1200.kilograms / cubicMeter
+val volFlowRate: VolumeFlow = 10.gallons / minute
+val flowTime: Time = 30.minutes
+val totalMassFlow: Mass = volFlowRate * flowTime * density
 ```
 
 ### Domain Modeling
 Another excellent use case for Squants is stronger typing for fields in your domain model.
 
 Code samples in this section use these imports:
-```scala
+```tut:silent:reset
 import scala.language.postfixOps
 
 import squants.energy.{Energy, Power, PowerRamp}
@@ -1021,7 +765,7 @@ import squants.time.TimeConversions._
 
 This is OK ...
 
-```scala
+```tut:silent
 case class Generator(
   id: String,
   maxLoadKW: Double,
@@ -1036,7 +780,7 @@ val gen2 = Generator("Gen2", 100, 250, 2944.5, "JPY", 0.5)
 
 ... but this is much better
 
-```scala
+```tut:silent
 case class Generator(
   id: String,
   maxLoad: Power,


### PR DESCRIPTION
This resolves #177 .

Most of the bugs I've submitted over the past few weeks have been found by running tut on the README. All of the examples in the README now compile with tut.

I made some stylistic changes in the README in this PR. I made the imports more prominent, since I assumed users could get confused about what imports they need (I know I was when i was new to the project). If reviews don't like that change, I can remove it and just pull in everything like the `squantsJVM/console` task does.

If this PR gets merged, I'll submit a followup PR to run tut as part of the Travis checks.