### PR TITLE
Frequency Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,14 +802,20 @@ scala> val low = 40.dollars / megawattHour
 low: squants.market.Price[squants.energy.Energy] = 40.0 USD/1.0 MWh
 ```
 
-Implicit conversion support for using Double on the left side of multiplication:
+Implicit conversion support for using Doubles, Longs and BigDecimals on the left side of multiply and divide operations:
 
 ```scala
-scala> val load = 10 * 4.MW
-load: squants.energy.Power = 40.0 MW
+scala> val load = 10.22 * 4.MW
+load: squants.energy.Power = 40.88 MW
 
 scala> val driveArrayCapacity = 12 * 600.gb
 driveArrayCapacity: squants.information.Information = 7200.0 GB
+
+scala> val freq = 60 / second
+freq: squants.time.Frequency = 60.0 Hz
+
+scala> val freq2 = BigDecimal(36000000) / hour
+freq2: squants.time.Frequency = 10000.0 Hz
 ```
 
 Create Quantity Ranges using `to` or `plusOrMinus` (`+-`) operators:

--- a/shared/src/main/scala/squants/package.scala
+++ b/shared/src/main/scala/squants/package.scala
@@ -1,3 +1,5 @@
+import squants.time.Frequency
+
 /*                                                                      *\
 ** Squants                                                              **
 **                                                                      **
@@ -73,7 +75,7 @@ package object squants {
   type Price[A <: Quantity[A]] = squants.market.Price[A]
 
   /**
-   * Provides implicit conversions that allow Doubles to lead in * operations
+   * Provides implicit conversions that allow Doubles to lead in * and / by Time operations
    * {{{
    *    1.5 * Kilometers(10) should be(Kilometers(15))
    * }}}
@@ -83,10 +85,12 @@ package object squants {
   implicit class SquantifiedDouble(d: Double) {
     def *[A <: Quantity[A]](that: A): A = that * d
     def *[A](that: SVector[A]): SVector[A] = that * d
+    def /(that: Time): Frequency = Each(d) / that
+    def per(that: Time): Frequency = /(that)
   }
 
   /**
-   * Provides implicit conversions that allow Longs to lead in * operations
+   * Provides implicit conversions that allow Longs to lead in * and / by Time operations
    * {{{
    *    5 * Kilometers(10) should be(Kilometers(15))
    * }}}
@@ -96,10 +100,12 @@ package object squants {
   implicit class SquantifiedLong(l: Long) {
     def *[A <: Quantity[A]](that: A): A = that * l.toDouble
     def *[A](that: SVector[A]): SVector[A] = that * l.toDouble
+    def /(that: Time) = Each(l) / that
+    def per(that: Time): Frequency = /(that)
   }
 
   /**
-   * Provides implicit conversions that allow BigDecimals to lead in * operations
+   * Provides implicit conversions that allow BigDecimals to lead in * and / by Time operations
    * {{{
    *    BigDecimal(1.5) * Kilometers(10) should be(Kilometers(15))
    * }}}
@@ -109,6 +115,8 @@ package object squants {
   implicit class SquantifiedBigDecimal(bd: BigDecimal) {
     def *[A <: Quantity[A]](that: A): A = that * bd.toDouble
     def *[A](that: SVector[A]): SVector[A] = that * bd.toDouble
+    def /(that: Time) = Each(bd) / that
+    def per(that: Time): Frequency = /(that)
   }
 
   /**

--- a/shared/src/main/scala/squants/time/Frequency.scala
+++ b/shared/src/main/scala/squants/time/Frequency.scala
@@ -9,6 +9,10 @@
 package squants.time
 
 import squants._
+import squants.electro.{ ElectricCharge, ElectricPotential, MagneticFlux }
+import squants.information.{ DataRate, Information }
+import squants.motion.{ AngularVelocity, Pressure, PressureChange, Yank }
+import squants.photo.{ Illuminance, LuminousEnergy, LuminousExposure, LuminousFlux }
 
 /**
  * Represents a quantity of frequency, which is the number cycles (count) over time
@@ -25,6 +29,24 @@ final class Frequency private (val value: Double, val unit: FrequencyUnit)
 
   protected[squants] def timeIntegrated = Each(toHertz)
   protected[squants] def time = Seconds(1)
+
+  def *(that: Acceleration): Jerk = that * this
+  def *(that: Angle): AngularVelocity = that * this
+  def *(that: Dimensionless): Frequency = this * that.toEach
+  def *(that: ElectricCharge): ElectricCurrent = that * this
+  def *(that: Energy): Power = that * this
+  def *(that: Force): Yank = that * this
+  def *(that: Information): DataRate = that * this
+  def *(that: Length): Velocity = that * this
+  def *(that: LuminousEnergy): LuminousFlux = that * this
+  def *(that: LuminousExposure): Illuminance = that * this
+  def *(that: MagneticFlux): ElectricPotential = that * this
+  def *(that: Mass): MassFlow = that * this
+  def *(that: Momentum): Force = that * this
+  def *(that: Power): PowerRamp = that * this
+  def *(that: Pressure): PressureChange = that * this
+  def *(that: Velocity): Acceleration = that * this
+  def *(that: Volume): VolumeFlow = that * this
 
   def toHertz = to(Hertz)
   def toKilohertz = to(Kilohertz)

--- a/shared/src/main/scala/squants/time/TimeDerivative.scala
+++ b/shared/src/main/scala/squants/time/TimeDerivative.scala
@@ -65,6 +65,14 @@ trait TimeIntegral[A <: Quantity[A] with TimeDerivative[_]] { self: Quantity[_] 
    * @return
    */
   def /(that: A): Time = that.time * (timeDerived / that)
+
+  /**
+    * Returns the Time Derivative of this Quantity based on the Frequency this Quantity occurs
+    *
+    * @param that Frequency - the rate at which this Quantity occurs
+    * @return
+    */
+  def *(that: Frequency): A = /(time) * (time * that).toEach
 }
 
 trait SecondTimeIntegral[A <: SecondTimeDerivative[_]] { self: TimeIntegral[_] ⇒

--- a/shared/src/main/tut/README.md
+++ b/shared/src/main/tut/README.md
@@ -584,11 +584,13 @@ val hi = 100.dollars / MWh
 val low = 40.dollars / megawattHour
 ```
 
-Implicit conversion support for using Double on the left side of multiplication:
+Implicit conversion support for using Doubles, Longs and BigDecimals on the left side of multiply and divide operations:
 
 ```tut
-val load = 10 * 4.MW
+val load = 10.22 * 4.MW
 val driveArrayCapacity = 12 * 600.gb
+val freq = 60 / second
+val freq2 = BigDecimal(36000000) / hour
 ```
 
 Create Quantity Ranges using `to` or `plusOrMinus` (`+-`) operators:

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -8,12 +8,11 @@
 
 package squants
 
-import org.scalatest.{FlatSpec, Matchers}
-import squants.thermal.{Celsius, Fahrenheit}
-import squants.time.Hours
-
+import org.scalatest.{ FlatSpec, Matchers }
 import scala.math.BigDecimal.RoundingMode
 import scala.util.Failure
+import squants.thermal.{ Celsius, Fahrenheit }
+import squants.time.{ Hertz, Hours }
 
 /**
  * @author  garyKeorkunian
@@ -540,6 +539,11 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
     (m to Kilograms) should be(500)
   }
 
+  it should "divide by a Time value and return a Frequency" in {
+    10D / Seconds(1) should be(Hertz(10))
+    10D per Seconds(1) should be(Hertz(10))
+  }
+
   behavior of "SquantifiedLong"
 
   it should "multiply by a Quantity value and return the product as a like value" in {
@@ -550,6 +554,11 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
     val m = 10L * Kilograms(50)
     m.getClass should be(classOf[Mass])
     (m to Kilograms) should be(500)
+  }
+
+  it should "divide by a Time value and return a Frequency" in {
+    10L / Seconds(1) should be(Hertz(10))
+    10L per Seconds(1) should be(Hertz(10))
   }
 
   behavior of "SquantifiedBigDecimal"
@@ -564,6 +573,11 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
     val m = multiple * Kilograms(50)
     m.getClass should be(classOf[Mass])
     (m to Kilograms) should be(500)
+  }
+
+  it should "divide by a Time value and return a Frequency" in {
+    BigDecimal(10) / Seconds(1) should be(Hertz(10))
+    BigDecimal(10) per Seconds(1) should be(Hertz(10))
   }
 
   behavior of "QuantityNumeric"

--- a/shared/src/test/scala/squants/time/FrequencySpec.scala
+++ b/shared/src/test/scala/squants/time/FrequencySpec.scala
@@ -9,6 +9,13 @@
 package squants.time
 
 import org.scalatest.{ FlatSpec, Matchers }
+import squants.electro.{ Amperes, Coulombs, Volts, Webers }
+import squants.energy.{ WattHours, Watts, WattsPerHour }
+import squants.information.{ Bytes, BytesPerSecond }
+import squants.mass.Kilograms
+import squants.motion._
+import squants.photo.{ LumenSeconds, Lumens, Lux, LuxSeconds }
+import squants.space.{ CubicMeters, Meters, Radians }
 import squants.{ Each, MetricSystem, QuantityParseException }
 
 /**
@@ -60,6 +67,26 @@ class FrequencySpec extends FlatSpec with Matchers {
 
   it should "return Count when multiplied by Time" in {
     Hertz(1) * Seconds(1) should be(Each(1))
+  }
+
+  it should "return the TimeDerivative when multiplied by a TimeIntegral" in {
+    Hertz(100) * FeetPerSecondSquared(100) should be(FeetPerSecondCubed(10000))
+    Hertz(100) * Radians(100) should be(RadiansPerSecond(10000))
+    Hertz(100) * Each(100) should be(Hertz(10000))
+    Hertz(100) * Coulombs(100) should be(Amperes(10000))
+    Hertz(100) * WattHours(100) should be(Watts(36000000))
+    Hertz(100) * Newtons(100) should be(NewtonsPerSecond(10000))
+    Hertz(100) * Bytes(100) should be(BytesPerSecond(10000))
+    Hertz(100) * Meters(100) should be(MetersPerSecond(10000))
+    Hertz(100) * LumenSeconds(100) should be(Lumens(10000))
+    Hertz(100) * LuxSeconds(100) should be(Lux(10000))
+    Hertz(100) * Webers(100) should be(Volts(10000))
+    Hertz(100) * Kilograms(100) should be(KilogramsPerSecond(10000))
+    Hertz(100) * NewtonSeconds(100) should be(Newtons(10000))
+    Hertz(100) * Watts(100) should be(WattsPerHour(36000000))
+    Hertz(100) * Pascals(100) should be(PascalsPerSecond(10000))
+    Hertz(100) * MetersPerSecond(100) should be(MetersPerSecondSquared(10000))
+    Hertz(100) * CubicMeters(100) should be(CubicMetersPerSecond(10000))
   }
 
   behavior of "FrequencyConversions"

--- a/shared/src/test/scala/squants/time/TimeDerivativeSpec.scala
+++ b/shared/src/test/scala/squants/time/TimeDerivativeSpec.scala
@@ -37,4 +37,9 @@ class TimeDerivativeSpec extends FlatSpec with Matchers with CustomMatchers {
     implicit val tolerance = Hours(0.0000000000001)
     Hours(2) should beApproximately(UsMiles(110) / UsMilesPerHour(55))
   }
+
+  it should "satisfy Derivative = Integral * Frequency" in {
+    implicit val tolerance = UsMilesPerHour(0.0000000000001)
+    UsMilesPerHour(55) should beApproximately(UsMiles(55) * 1/Hours(1))
+  }
 }


### PR DESCRIPTION
Added /(Time) and per(Time) to Squantified numbers to support expression like:

```scala
val f: Frequency = 1000 / second
val f: Frequency = 1000 per second
```

Added *(Frequency) to TimeIntegral to support conversions like:

```scala
val dr: DataRate = 1000.bytes * 10/second
```

Added *(TimeIntegral) to Frequency to support the same conversion with reversed operands:

```scala
val dr: DataRate = 10/second * 1000.bytes
```

However, this last expression returns type Any and needs to be reviewed for ideas on how to fix that before this is merged.

This is intended to close #134 