### PR TITLE
Stabilized toString output for MoneyContext and MoneyNumeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ scala> val exchangeRates = List(USD / CAD(1.05), USD / MXN(12.50), USD / JPY(100
 exchangeRates: List[squants.market.CurrencyExchangeRate] = List(USD/CAD 1.05, USD/MXN 12.5, USD/JPY 100.0)
 
 scala> implicit val moneyContext = defaultMoneyContext withExchangeRates exchangeRates
-moneyContext: squants.market.MoneyContext = MoneyContext(USD,Set(XAG, EUR, CAD, CHF, AUD, BTC, INR, XAU, SEK, DKK, JPY, NOK, GBP, NZD, RUB, CZK, MYR, CNY, ARS, KRW, CLP, HKD, BRL, USD, MXN),List(USD/CAD 1.05, USD/MXN 12.5, USD/JPY 100.0),true)
+moneyContext: squants.market.MoneyContext = MoneyContext(DefaultCurrency(USD),Currencies(ARS,AUD,BRL,BTC,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,INR,JPY,KRW,MXN,MYR,NOK,NZD,RUB,SEK,USD,XAG,XAU),ExchangeRates(USD/CAD 1.05,USD/JPY 100.0,USD/MXN 12.5),AllowIndirectConversions(true))
 
 scala> val energyPrice = USD(102.20) / MegawattHours(1)
 energyPrice: squants.market.Price[squants.energy.Energy] = 102.2 USD/1.0 MWh
@@ -856,7 +856,7 @@ implicit val moneyContext = defaultMoneyContext
 
 ```scala
 scala> implicit val moneyNum = new MoneyNumeric()
-moneyNum: squants.market.MoneyConversions.MoneyNumeric = squants.market.MoneyConversions$MoneyNumeric@14bb3847
+moneyNum: squants.market.MoneyConversions.MoneyNumeric = MoneyNumeric(MoneyContext(DefaultCurrency(USD),Currencies(ARS,AUD,BRL,BTC,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,INR,JPY,KRW,MXN,MYR,NOK,NZD,RUB,SEK,USD,XAG,XAU),ExchangeRates(),AllowIndirectConversions(true)))
 
 scala> val sum = List(USD(100), USD(10)).sum
 sum: squants.market.Money = 110.0 USD
@@ -996,7 +996,7 @@ import squants.time.TimeConversions._
 
 ```scala
 scala> implicit val moneyContext = defaultMoneyContext
-moneyContext: squants.market.MoneyContext = MoneyContext(USD,Set(XAG, EUR, CAD, CHF, AUD, BTC, INR, XAU, SEK, DKK, JPY, NOK, GBP, NZD, RUB, CZK, MYR, CNY, ARS, KRW, CLP, HKD, BRL, USD, MXN),List(),true)
+moneyContext: squants.market.MoneyContext = MoneyContext(DefaultCurrency(USD),Currencies(ARS,AUD,BRL,BTC,CAD,CHF,CLP,CNY,CZK,DKK,EUR,GBP,HKD,INR,JPY,KRW,MXN,MYR,NOK,NZD,RUB,SEK,USD,XAG,XAU),ExchangeRates(),AllowIndirectConversions(true))
 
 scala> val energyPrice: Price[Energy] = 45.25.money / megawattHour
 energyPrice: squants.market.Price[squants.energy.Energy] = 45.25 USD/1.0 MWh

--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -469,5 +469,11 @@ object MoneyConversions {
     def toFloat(x: Money) = x.value.toFloat
     def toDouble(x: Money) = x.value
     def compare(x: Money, y: Money) = if (x.value > y.value) 1 else if (x.value < y.value) -1 else 0
+
+    /**
+      * Custom implementation using SortedSets to ensure consistent output
+      * @return String representation of this instance
+      */
+    override def toString: String = s"MoneyNumeric($mc)"
   }
 }

--- a/shared/src/main/scala/squants/market/MoneyContext.scala
+++ b/shared/src/main/scala/squants/market/MoneyContext.scala
@@ -8,6 +8,8 @@
 
 package squants.market
 
+import scala.collection.SortedSet
+
 /**
  * MoneyContext
  *
@@ -23,7 +25,6 @@ package squants.market
  *
  * @author  garyKeorkunian
  * @since   0.1
- *
  * @param defaultCurrency Currency used when none is supplied to the Money factory
  * @param rates Collection of Exchange Rates used for currency conversions
  */
@@ -32,6 +33,17 @@ case class MoneyContext(
     currencies: Set[Currency],
     rates: Seq[CurrencyExchangeRate],
     allowIndirectConversions: Boolean = true) {
+
+  /**
+    * Custom implementation using SortedSets to ensure consistent output
+    * @return String representation of this instance
+    */
+  override def toString: String = string
+  private lazy val string = {
+    val cSet = currencies.map(_.toString).toSeq.sorted.mkString(",")
+    val rSet = rates.map(_.toString).sorted.mkString(",")
+    s"MoneyContext(DefaultCurrency(${defaultCurrency.code}),Currencies($cSet),ExchangeRates($rSet),AllowIndirectConversions($allowIndirectConversions))"
+  }
 
   /**
    * Returns an Option on an exchange rate if a direct rate exists, otherwise None


### PR DESCRIPTION
* Added custom `toString` methods to `MoneyContext` and `MoneyNumeric` to stabilize their output.  This should prevent thrash in the README file on each run of `tut`.

No tests should be required for these methods, as they are primarily used in the REPL and production application code should generally not depend on these values.