### PR TITLE
add SiUnit trait to SI units in mass package

### DIFF
--- a/shared/src/main/scala/squants/mass/AreaDensity.scala
+++ b/shared/src/main/scala/squants/mass/AreaDensity.scala
@@ -54,7 +54,7 @@ object KilogramsPerHectare extends AreaDensityUnit with UnitConverter {
   val conversionFactor = 1/(100*100d)
 }
 
-object GramsPerSquareCentimeter extends AreaDensityUnit with UnitConverter {
+object GramsPerSquareCentimeter extends AreaDensityUnit with UnitConverter with SiUnit {
   val symbol = "g/cm²"
   val conversionFactor = (100*100d)/1000d
 }

--- a/shared/src/main/scala/squants/mass/Density.scala
+++ b/shared/src/main/scala/squants/mass/Density.scala
@@ -36,11 +36,11 @@ object Density extends Dimension[Density] {
   def units = Set(KilogramsPerCubicMeter)
 }
 
-trait DensityUnit extends UnitOfMeasure[Density] with UnitConverter with SiUnit {
+trait DensityUnit extends UnitOfMeasure[Density] with UnitConverter {
   def apply[A](n: A)(implicit num: Numeric[A]) = Density(n, this)
 }
 
-object KilogramsPerCubicMeter extends DensityUnit with PrimaryUnit {
+object KilogramsPerCubicMeter extends DensityUnit with PrimaryUnit with SiUnit {
   val symbol = "kg/m³"
 }
 

--- a/shared/src/main/scala/squants/mass/Mass.scala
+++ b/shared/src/main/scala/squants/mass/Mass.scala
@@ -79,16 +79,16 @@ trait MassUnit extends UnitOfMeasure[Mass] with UnitConverter {
   def apply[A](n: A)(implicit num: Numeric[A]) = Mass(n, this)
 }
 
-object Grams extends MassUnit with PrimaryUnit {
+object Grams extends MassUnit with PrimaryUnit with SiUnit {
   val symbol = "g"
 }
 
-object Micrograms extends MassUnit {
+object Micrograms extends MassUnit with SiUnit {
   val conversionFactor = MetricSystem.Micro
   val symbol = "mcg"
 }
 
-object Milligrams extends MassUnit {
+object Milligrams extends MassUnit with SiUnit {
   val conversionFactor = MetricSystem.Milli
   val symbol = "mg"
 }


### PR DESCRIPTION
This is in service of #215 .

I also fixed a bug where all `DensityUnit`s were annotated with `SiUnit` (`SiUnit` was mixed into the `DensityUnit` base trait).