### PR TITLE
Add Scala Native as a supported platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,10 @@ before_cache:
 
 script:
   # Your normal script
-  - sbt ++$TRAVIS_SCALA_VERSION test:compile squantsJS/fastOptJS
+  - sbt ++$TRAVIS_SCALA_VERSION squantsJVM/test:compile squantsJS/test:compile squantsJS/fastOptJS
+  - if [[ $TRAVIS_SCALA_VERSION == "2.11.8" ]]; then sbt ++$TRAVIS_SCALA_VERSION squantsNative/compile; fi;
   - sbt ++$TRAVIS_SCALA_VERSION squantsJS/test squantsJVM/test
-  - sbt ++$TRAVIS_SCALA_VERSION doc tut
+  - sbt ++$TRAVIS_SCALA_VERSION squantsJS/doc squantsJVM/doc tut
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/README.md
+++ b/README.md
@@ -1224,9 +1224,11 @@ To make a release do the following:
   sbt tut
 ```
 
-* Publish a cross-version signed package
+* Publish a cross-version signed package (no cross-version available for Scala Native)
 ```
-  sbt +publishSigned
+  sbt +squantsJVM/publishSigned
+  sbt +squantsJS/publishSigned
+  sbt squantsNative/publishSigned
 ```
 
 * Then make a release (Note: after this step the release cannot be replaced)

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtcrossproject.{crossProject, CrossType}
+
 lazy val defaultSettings =
   Project.defaultSettings ++
   Compiler.defaultSettings ++
@@ -7,7 +9,7 @@ lazy val defaultSettings =
   Console.defaultSettings ++
   Docs.defaultSettings
 
-lazy val squants = crossProject
+lazy val squants = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Full)
   .in(file("."))
   .settings(defaultSettings: _*)
@@ -30,7 +32,8 @@ lazy val root = project.in(file("."))
     publishLocal := {},
     publishArtifact := false
   )
-  .aggregate(squantsJVM, squantsJS)
+  .aggregate(squantsJVM, squantsJS, squantsNative)
 
 lazy val squantsJVM = squants.jvm.enablePlugins(SbtOsgi)
 lazy val squantsJS = squants.js
+lazy val squantsNative = squants.native

--- a/js/src/main/scala/squants/Platform.scala
+++ b/js/src/main/scala/squants/Platform.scala
@@ -1,0 +1,18 @@
+package squants
+
+object Platform {
+  /**
+   * Helper function to achieve uniform Double formatting over JVM and JS platforms.
+   * Simple Double.toString will format 1.0 as "1.0" on JVM and as "1" on JS
+   * @param d Double number to be formatted
+   * @return
+   */
+  private[squants] def crossFormat(d: Double): String = {
+    if (d.toLong == d) {
+      "%.1f".format(d)
+    }
+    else {
+      d.toString
+    }
+  }
+}

--- a/jvm/src/main/scala/squants/Platform.scala
+++ b/jvm/src/main/scala/squants/Platform.scala
@@ -1,0 +1,18 @@
+package squants
+
+object Platform {
+  /**
+   * Helper function to achieve uniform Double formatting over JVM, JS, and native platforms.
+   * Simple Double.toString will format 1.0 as "1.0" on JVM and as "1" on JS
+   * @param d Double number to be formatted
+   * @return
+   */
+  private[squants] def crossFormat(d: Double): String = {
+    if (d.toLong == d) {
+      "%.1f".format(d)
+    }
+    else {
+      d.toString
+    }
+  }
+}

--- a/native/src/main/scala/squants/Platform.scala
+++ b/native/src/main/scala/squants/Platform.scala
@@ -1,0 +1,15 @@
+package squants
+
+object Platform {
+  /**
+   * Helper function to achieve uniform Double formatting over JVM, JS, and native platforms.
+   * Simple Double.toString will format 1.0 as "1.0" on JVM and as "1" on JS
+   * @param d Double number to be formatted
+   * @return
+   */
+  private[squants] def crossFormat(d: Double): String = {
+    // we cannot use the same logic as JS and JVM because string formatting is not supported
+    // by Scala Native yet
+    d.toString
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,11 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
 
+addSbtPlugin("org.scala-native" % "sbt-crossproject" % "0.1.0")
+
+addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.1.0")
+
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.2.1")
+
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")

--- a/shared/src/main/scala/squants/Quantity.scala
+++ b/shared/src/main/scala/squants/Quantity.scala
@@ -277,7 +277,7 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @param uom UnitOfMeasure[A] with UnitConverter
    * @return String
    */
-  def toString(uom: UnitOfMeasure[A]): String = s"${crossFormat(to(uom))} ${uom.symbol}"
+  def toString(uom: UnitOfMeasure[A]): String = s"${Platform.crossFormat(to(uom))} ${uom.symbol}"
 
   /**
    * Returns a string representing the quantity's value in the given `unit` in the given `format`

--- a/shared/src/main/scala/squants/market/CurrencyExchangeRate.scala
+++ b/shared/src/main/scala/squants/market/CurrencyExchangeRate.scala
@@ -8,7 +8,8 @@
 
 package squants.market
 
-import squants.{ Ratio, crossFormat }
+import squants.Ratio
+import squants.Platform.crossFormat
 
 /**
  * Represent the rate of exchange between two currencies

--- a/shared/src/main/scala/squants/package.scala
+++ b/shared/src/main/scala/squants/package.scala
@@ -118,12 +118,4 @@ package object squants {
     def /(that: Time) = Each(bd) / that
     def per(that: Time): Frequency = /(that)
   }
-
-  /**
-   * Helper function to achieve uniform Double formatting over JVM and JS platforms.
-   * Simple Double.toString will format 1.0 as "1.0" on JVM and as "1" on JS
-   * @param d Double number to be formatted
-   * @return
-   */
-  private[squants] def crossFormat(d: Double): String = if (d.toLong == d) { "%.1f".format(d) } else { d.toString }
 }

--- a/shared/src/main/scala/squants/thermal/Temperature.scala
+++ b/shared/src/main/scala/squants/thermal/Temperature.scala
@@ -9,6 +9,7 @@
 package squants.thermal
 
 import squants._
+import squants.Platform.crossFormat
 import squants.energy.Joules
 import scala.util.{ Failure, Success, Try }
 


### PR DESCRIPTION
This adds cross-compilation of Squants to Scala Native (for Scala 2.11 only). There is a small hack in `toString` for `Quantity` to work around string formatting being unimplemented in Scala Native. This also updates publishing instructions to handle Scala Native only supporting Scala 2.11.