### PR TITLE
update QuantityRange's error message and docs to clarify behavior

### DIFF
--- a/shared/src/main/scala/squants/QuantityRange.scala
+++ b/shared/src/main/scala/squants/QuantityRange.scala
@@ -21,7 +21,9 @@ import scala.annotation.tailrec
  * @tparam A the Quantity Type
  */
 case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
-  if (lower >= upper) throw new IllegalArgumentException("QuantityRange upper bound must be greater than or equal to the lower bound")
+  if (lower >= upper) {
+    throw new IllegalArgumentException("QuantityRange upper bound must be strictly greater than to the lower bound")
+  }
 
   /**
    * Create a Seq of `multiple` ranges equal in size to the original with sequential range values
@@ -254,7 +256,8 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
   def +-(that: A) = incFromDecTo(that)
 
   /**
-   * Returns true if the quantity is contained within this range, otherwise false
+   * Returns true if the quantity is contained within this range, otherwise false.
+   * This check is *exclusive* of the range's upper limit.
    * @param q Quantity
    * @return
    */
@@ -279,11 +282,12 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
   def partiallyContains(range: QuantityRange[A]) = range.lower < upper && range.upper > lower
 
   /**
-   * Returns true if `that` quantity is included within `this` range
+   * Returns true if `that` quantity is included within `this` range.
+   * This check is *inclusive* of the range's upper limit.
    * @param q Quantity
    * @return
    */
-  def includes(q: A) = q >= lower && q <= upper
+  def includes(q: A): Boolean = q >= lower && q <= upper
 
   /**
    * Returns true if `that` range is completely included in `this` range, otherwise false

--- a/shared/src/main/tut/README.md
+++ b/shared/src/main/tut/README.md
@@ -474,36 +474,84 @@ val northAmericanSales: Money = (CAD(275) + USD(350) + MXN(290)) in USD
 ```
 
 ## Quantity Ranges
-Used to represent a range of Quantity values between an upper and lower bound
+A `QuantityRange` is used to represent a range of Quantity values between an upper and lower bound:
 
-```tut:reset
+```tut:reset:silent
 import squants.QuantityRange
-import squants.energy.{Kilowatts, Power}
-
+import squants.energy.{Kilowatts, Megawatts, Power}
+```
+```tut:book
 val load1: Power = Kilowatts(1000)
 val load2: Power = Kilowatts(5000)
 val range: QuantityRange[Power] = QuantityRange(load1, load2)
 ```
 
-Use multiplication and division to create a Seq of ranges from the original
+### Inclusivity and Exclusivitiy
 
-```tut:silent
-// Create a Seq of 10 sequential ranges starting with the original and each the same size as the original
+The `QuantityRange` constructor requires that `upper` is strictly greater than `lower`:
+
+```tut:book
+import squants.space.LengthConversions._
+
+// this will work b/c upper > lower
+QuantityRange(1.km, 5.km)
+```
+
+This will fail because `lower` = `upper`:
+
+```tut:fail
+QuantityRange(1.km, 1.km)
+```
+
+`QuantityRange` contains two functions that check if an element is part of the range, `contains` and `includes`. 
+These differ in how they treat the range's upper bound: `contains()` _excludes_ it but `includes()` _includes_ it.
+
+```tut
+val distances = QuantityRange(1.km, 5.km)
+distances.contains(5.km) // this is false b/c contains() doesn't include the upper range
+distances.includes(5.km) // this is true b/c includes() does include the upper range
+```
+
+### QuantityRange transformation
+
+The multiplication and division operators create a `Seq` of ranges from the original.
+
+For example:
+
+Create a Seq of 10 sequential ranges starting with the original and each the same size as the original:
+```tut:book
 val rs1 = range * 10
-// Create a Seq of 10 sequential ranges each 1/10th of the original size
+```
+Create a Seq of 10 sequential ranges each 1/10th of the original size:
+
+```tut:book
 val rs2 = range / 10
-// Create a Seq of 10 sequential ranges each with a size of 400 kilowatts
+```
+
+Create a Seq of 10 sequential ranges each with a size of 400 kilowatts:
+```tut:book
 val rs3 = range / Kilowatts(400)
 ```
-Apply foreach, map and foldLeft/foldRight directly to QuantityRanges with a divisor
 
-```tut:silent:fail
-// foreach over each of the 400 kilometer ranges within the range
-range.foreach(Kilometers(400)) {r => ???}
-// map over each of 10 even parts of the range
-range.map(10) {r => ???}
-// fold over each 10 even parts of the range
-range.foldLeft(10)(0) {(z, r) => ???}
+### QuantityRange operations
+
+`QuantityRange` supports foreach, map, and foldLeft/foldRight. These vary slightly from the versions
+in the Scala standard library in that they take a divisior as the first parameter. The examples below 
+illustrate their use.
+
+Subdivide range into 1-Megawatt "slices", and foreach over each of slices:
+```tut:book
+range.foreach(Megawatts(1)) { r => println(s"lower = ${r.lower}, upper = ${r.upper}") }
+```
+
+Subdivide range into 10 slices and map over each slice:
+```tut:book
+range.map(10) { r => r.upper }
+```
+
+Subdivide range into 10 slices and fold over them, using 0 Megawatts as a starting value:
+```tut:book
+range.foldLeft(10, Megawatts(0)) { (z, r) => z + r.upper }
 ```
 
 NOTE - Because these implementations of foreach, map and fold* take a parameter (the divisor), these methods
@@ -771,6 +819,7 @@ we're adding support for `Length`.
 ```tut:reset:silent
 import squants.experimental.formatter.DefaultFormatter
 import squants.experimental.formatter.syntax._
+import squants.mass.MassConversions._
 import squants.space.Length
 import squants.space.LengthConversions._
 import squants.experimental.unitgroups.misc.AstronomicalLengthUnitGroup

--- a/shared/src/test/scala/squants/QuantityRangeSpec.scala
+++ b/shared/src/test/scala/squants/QuantityRangeSpec.scala
@@ -20,8 +20,12 @@ class QuantityRangeSpec extends FlatSpec with Matchers {
 
   behavior of "QuantityRange"
 
-  it should "throw an IllegalArgumentException when the lower bound >= upper bound" in {
+  it should "throw an IllegalArgumentException when the lower bound > upper bound" in {
     an[IllegalArgumentException] should be thrownBy QuantityRange(Meters(2), Meters(1))
+  }
+
+  it should "throw an IllegalArgumentException when the lower bound = upper bound" in {
+    an[IllegalArgumentException] should be thrownBy QuantityRange(Meters(2), Meters(2))
   }
 
   it should "create a range with lower and upper bound" in {


### PR DESCRIPTION
This closes #242 and #243 .

It turns out `QuantityRange` already had the inclusive behavior I wanted, so I updated the README and ScalaDoc to clarify that. I also changed the wording in the constructor's exception message to correctly describe the check.

In a later PR (post-1.3.0) we can add safe building functions that return an Option or Either instead of throwing exceptions.