### PR TITLE
add permittivity type and implement unimplemented capacitance function

### DIFF
--- a/shared/src/main/scala/squants/electro/Capacitance.scala
+++ b/shared/src/main/scala/squants/electro/Capacitance.scala
@@ -22,7 +22,7 @@ final class Capacitance private (val value: Double, val unit: CapacitanceUnit)
   def dimension = Capacitance
 
   def *(that: ElectricPotential): ElectricCharge = Coulombs(this.toFarads * that.toVolts)
-  def /(that: Length) = ??? // returns Permittivity
+  def /(that: Length): Permittivity = FaradsMeters(this.toFarads / that.toMeters)
 
   def toFarads = to(Farads)
   def toPicofarads = to(Picofarads)

--- a/shared/src/main/scala/squants/electro/Permittivity.scala
+++ b/shared/src/main/scala/squants/electro/Permittivity.scala
@@ -1,0 +1,48 @@
+package squants.electro
+
+import squants.space.{Length, Meters}
+import squants.{AbstractQuantityNumeric, Dimension, PrimaryUnit, Quantity, SiUnit, UnitConverter, UnitOfMeasure}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  * @param value Double
+  */
+final class Permittivity private (val value: Double, val unit: PermittivityUnit)
+    extends Quantity[Permittivity] {
+
+  def dimension = Permittivity
+
+  def *(that: Length): Capacitance = Farads(this.toFaradsMeters * that.toMeters)
+
+  def toFaradsMeters = to(FaradsMeters)
+}
+
+object Permittivity extends Dimension[Permittivity] {
+  private[electro] def apply[A](n: A, unit: PermittivityUnit)(implicit num: Numeric[A]) = new Permittivity(num.toDouble(n), unit)
+  def apply = parse _
+  def name = "Permittivity"
+  def primaryUnit = FaradsMeters
+  def siUnit = FaradsMeters
+  def units = Set(FaradsMeters)
+}
+
+trait PermittivityUnit extends UnitOfMeasure[Permittivity] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = Permittivity(n, this)
+}
+
+object FaradsMeters extends PermittivityUnit with PrimaryUnit with SiUnit {
+  def symbol = Farads.symbol + "/" + Meters.symbol
+}
+
+object PermittivityConversions {
+  lazy val faradMeter = FaradsMeters(1)
+
+  implicit class PermittivityConversions[A](n: A)(implicit num: Numeric[A]) {
+    def faradsMeters = FaradsMeters(n)
+  }
+
+  implicit object PermittivityNumeric extends AbstractQuantityNumeric[Permittivity](Permittivity.primaryUnit)
+}

--- a/shared/src/main/scala/squants/experimental/unitgroups/ImplicitDimensions.scala
+++ b/shared/src/main/scala/squants/experimental/unitgroups/ImplicitDimensions.scala
@@ -29,6 +29,7 @@ object ImplicitDimensions {
     implicit val implicitMagneticFlux: Dimension[MagneticFlux] = MagneticFlux
     implicit val implicitMagneticFluxDensity: Dimension[MagneticFluxDensity] = MagneticFluxDensity
     implicit val implicitResistivity: Dimension[Resistivity] = Resistivity
+    implicit val implicitPermittivity: Dimension[Permittivity] = Permittivity
   }
 
   object energy {

--- a/shared/src/test/scala/squants/electro/CapacitanceSpec.scala
+++ b/shared/src/test/scala/squants/electro/CapacitanceSpec.scala
@@ -8,8 +8,9 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
-import squants.{ QuantityParseException, MetricSystem }
+import org.scalatest.{FlatSpec, Matchers}
+import squants.space.Meters
+import squants.{MetricSystem, QuantityParseException}
 
 /**
  * @author  garyKeorkunian
@@ -61,6 +62,10 @@ class CapacitanceSpec extends FlatSpec with Matchers {
 
   it should "return ElectricalCharge when multiplied by ElectricalPotential" in {
     Farads(1) * Volts(1) should be(Coulombs(1))
+  }
+
+  it should "return Permittivity when divided by Length" in {
+    Farads(1) / Meters(1) should be(FaradsMeters(1))
   }
 
   behavior of "CapacitanceConversions"

--- a/shared/src/test/scala/squants/electro/PermittivitySpec.scala
+++ b/shared/src/test/scala/squants/electro/PermittivitySpec.scala
@@ -1,0 +1,60 @@
+package squants.electro
+
+import org.scalatest.{FlatSpec, Matchers}
+import squants.QuantityParseException
+import squants.space.Meters
+
+/**
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  */
+class PermittivitySpec extends FlatSpec with Matchers {
+
+  behavior of "Permittivity and its Units of Measure"
+
+  it should "create values using UOM factories" in {
+    FaradsMeters(1).toFaradsMeters should be(1)
+  }
+
+  it should "create values from properly formatted Strings" in {
+    Permittivity("10.22 F/m").get should be(FaradsMeters(10.22))
+    Permittivity("10.22 zz").failed.get should be(QuantityParseException("Unable to parse Permittivity", "10.22 zz"))
+    Permittivity("zz F/m").failed.get should be(QuantityParseException("Unable to parse Permittivity", "zz F/m"))
+  }
+
+  it should "properly convert to all supported Units of Measure" in {
+    val x = FaradsMeters(10)
+    x.toFaradsMeters should be(10.0)
+  }
+
+  it should "return properly formatted strings for all supported Units of Measure" in {
+    FaradsMeters(1).toString(FaradsMeters) should be("1.0 F/m")
+  }
+
+  it should "return Capacitance when multiplied by Length" in {
+    FaradsMeters(1) * Meters(1) should be(Farads(1))
+  }
+
+  behavior of "PermittivityConversions"
+
+  it should "provide aliases for single unit values" in {
+    import PermittivityConversions._
+
+    faradMeter should be(FaradsMeters(1))
+  }
+
+  it should "provide implicit conversion from Double" in {
+    import PermittivityConversions._
+
+    val d = 10.22
+    d.faradsMeters should be(FaradsMeters(d))
+  }
+
+  it should "provide Numeric support" in {
+    import PermittivityConversions.PermittivityNumeric
+
+    val rs = List(FaradsMeters(100), FaradsMeters(10))
+    rs.sum should be(FaradsMeters(110))
+  }
+}


### PR DESCRIPTION
This PR is the first of a series aiming to solve issue #252 .
In this PR one unimplemented function (/ by length) in capacitance was implemented as well as a new type needed (permittivity).