### PR TITLE
add AreaElectricChargeDensity, ElectricChargeDensity, ElectricChargeM…

### DIFF
--- a/shared/src/main/scala/squants/electro/AreaElectricChargeDensity.scala
+++ b/shared/src/main/scala/squants/electro/AreaElectricChargeDensity.scala
@@ -1,0 +1,49 @@
+package squants.electro
+
+import squants.space.Meters
+import squants.{AbstractQuantityNumeric, Area, Dimension, Length, PrimaryUnit, Quantity, SiUnit, UnitConverter, UnitOfMeasure}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  * @param value Double
+  */
+final class AreaElectricChargeDensity private (val value: Double, val unit: AreaElectricChargeDensityUnit)
+  extends Quantity[AreaElectricChargeDensity] {
+
+  def dimension = AreaElectricChargeDensity
+
+  def *(that: Area): ElectricCharge = Coulombs(this.toCoulombsSquareMeters * that.toSquareMeters)
+  def *(that: Length): LinearElectricChargeDensity = CoulombsPerMeter(this.toCoulombsSquareMeters * that.toMeters)
+
+  def toCoulombsSquareMeters = to(CoulombsPerSquareMeter)
+}
+
+object AreaElectricChargeDensity extends Dimension[AreaElectricChargeDensity] {
+  private[electro] def apply[A](n: A, unit: AreaElectricChargeDensityUnit)(implicit num: Numeric[A]) = new AreaElectricChargeDensity(num.toDouble(n), unit)
+  def apply = parse _
+  def name = "AreaElectricChargeDensity"
+  def primaryUnit = CoulombsPerSquareMeter
+  def siUnit = CoulombsPerSquareMeter
+  def units = Set(CoulombsPerSquareMeter)
+}
+
+trait AreaElectricChargeDensityUnit extends UnitOfMeasure[AreaElectricChargeDensity] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = AreaElectricChargeDensity(n, this)
+}
+
+object CoulombsPerSquareMeter extends AreaElectricChargeDensityUnit with PrimaryUnit with SiUnit {
+  val symbol = Coulombs.symbol + "/" + Meters.symbol + "²"
+}
+
+object AreaElectricChargeDensityConversions {
+  lazy val coulombPerSquareMeter = CoulombsPerSquareMeter(1)
+
+  implicit class AreaElectricChargeDensityConversions[A](n: A)(implicit num: Numeric[A]) {
+    def coulombsPerSquareMeter = CoulombsPerSquareMeter(n)
+  }
+
+  implicit object AreaElectricChargeDensityNumeric extends AbstractQuantityNumeric[AreaElectricChargeDensity](AreaElectricChargeDensity.primaryUnit)
+}

--- a/shared/src/main/scala/squants/electro/ElectricCharge.scala
+++ b/shared/src/main/scala/squants/electro/ElectricCharge.scala
@@ -30,10 +30,10 @@ final class ElectricCharge private (val value: Double, val unit: ElectricChargeU
   def *(that: ElectricPotential): Energy = Joules(this.toCoulombs * that.toVolts)
   def /(that: ElectricPotential): Capacitance = Farads(this.toCoulombs / that.toVolts)
   def /(that: Capacitance): ElectricPotential = Volts(this.toCoulombs / that.toFarads)
-  def /(that: Length) = ??? // returns LinearElectricChargeDensity
-  def /(that: Area) = ??? // returns AreaElectricChargeDensity
-  def /(that: Volume) = ??? // returns ElectricChargeDensity
-  def /(that: Mass) = ??? // returns ElectricChargeMassRatio
+  def /(that: Length): LinearElectricChargeDensity = CoulombsPerMeter(this.toCoulombs / that.toMeters)
+  def /(that: Area): AreaElectricChargeDensity = CoulombsPerSquareMeter(this.toCoulombs / that.toSquareMeters)
+  def /(that: Volume): ElectricChargeDensity = CoulombsPerCubicMeter(this.toCoulombs / that.toCubicMeters)
+  def /(that: Mass): ElectricChargeMassRatio = CoulombsPerKilogram(this.toCoulombs / that.toKilograms)
 
   def toCoulombs = to(Coulombs)
   def toPicocoulombs = to(Picocoulombs)

--- a/shared/src/main/scala/squants/electro/ElectricChargeDensity.scala
+++ b/shared/src/main/scala/squants/electro/ElectricChargeDensity.scala
@@ -1,0 +1,50 @@
+package squants.electro
+
+import squants.space.{Meters, Volume}
+import squants.{AbstractQuantityNumeric, Area, Dimension, Length, PrimaryUnit, Quantity, SiUnit, UnitConverter, UnitOfMeasure}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  * @param value Double
+  */
+final class ElectricChargeDensity private (val value: Double, val unit: ElectricChargeDensityUnit)
+  extends Quantity[ElectricChargeDensity] {
+
+  def dimension = ElectricChargeDensity
+
+  def *(that: Volume): ElectricCharge = Coulombs(this.toCoulombsCubicMeters * that.toCubicMeters)
+  def *(that: Area): LinearElectricChargeDensity = CoulombsPerMeter(this.toCoulombsCubicMeters * that.toSquareMeters)
+  def *(that: Length): AreaElectricChargeDensity = CoulombsPerSquareMeter(this.toCoulombsCubicMeters * that.toMeters)
+
+  def toCoulombsCubicMeters = to(CoulombsPerCubicMeter)
+}
+
+object ElectricChargeDensity extends Dimension[ElectricChargeDensity] {
+  private[electro] def apply[A](n: A, unit: ElectricChargeDensityUnit)(implicit num: Numeric[A]) = new ElectricChargeDensity(num.toDouble(n), unit)
+  def apply = parse _
+  def name = "ElectricChargeDensity"
+  def primaryUnit = CoulombsPerCubicMeter
+  def siUnit = CoulombsPerCubicMeter
+  def units = Set(CoulombsPerCubicMeter)
+}
+
+trait ElectricChargeDensityUnit extends UnitOfMeasure[ElectricChargeDensity] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricChargeDensity(n, this)
+}
+
+object CoulombsPerCubicMeter extends ElectricChargeDensityUnit with PrimaryUnit with SiUnit {
+  val symbol = Coulombs.symbol + "/" + Meters.symbol + "³"
+}
+
+object ElectricChargeDensityConversions {
+  lazy val coulombPerCubicMeter = CoulombsPerCubicMeter(1)
+
+  implicit class ElectricChargeDensityConversions[A](n: A)(implicit num: Numeric[A]) {
+    def coulombsPerCubicMeter = CoulombsPerCubicMeter(n)
+  }
+
+  implicit object ElectricChargeDensityNumeric extends AbstractQuantityNumeric[ElectricChargeDensity](ElectricChargeDensity.primaryUnit)
+}

--- a/shared/src/main/scala/squants/electro/ElectricChargeMassRatio.scala
+++ b/shared/src/main/scala/squants/electro/ElectricChargeMassRatio.scala
@@ -1,0 +1,48 @@
+package squants.electro
+
+import squants.mass.Kilograms
+import squants.{AbstractQuantityNumeric, Dimension, Mass, PrimaryUnit, Quantity, SiUnit, UnitConverter, UnitOfMeasure}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  * @param value Double
+  */
+final class ElectricChargeMassRatio private (val value: Double, val unit: ElectricChargeMassRatioUnit)
+  extends Quantity[ElectricChargeMassRatio] {
+
+  def dimension = ElectricChargeMassRatio
+
+  def *(that: Mass): ElectricCharge = Coulombs(this.toCoulombsKilograms * that.toKilograms)
+
+  def toCoulombsKilograms = to(CoulombsPerKilogram)
+}
+
+object ElectricChargeMassRatio extends Dimension[ElectricChargeMassRatio] {
+  private[electro] def apply[A](n: A, unit: ElectricChargeMassRatioUnit)(implicit num: Numeric[A]) = new ElectricChargeMassRatio(num.toDouble(n), unit)
+  def apply = parse _
+  def name = "ElectricChargeMassRatio"
+  def primaryUnit = CoulombsPerKilogram
+  def siUnit = CoulombsPerKilogram
+  def units = Set(CoulombsPerKilogram)
+}
+
+trait ElectricChargeMassRatioUnit extends UnitOfMeasure[ElectricChargeMassRatio] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricChargeMassRatio(n, this)
+}
+
+object CoulombsPerKilogram extends ElectricChargeMassRatioUnit with PrimaryUnit with SiUnit {
+  val symbol = Coulombs.symbol + "/" + Kilograms.symbol
+}
+
+object ElectricChargeMassRatioConversions {
+  lazy val coulombPerKilogram = CoulombsPerKilogram(1)
+
+  implicit class ElectricChargeMassRatioConversions[A](n: A)(implicit num: Numeric[A]) {
+    def coulombsPerKilogram = CoulombsPerKilogram(n)
+  }
+
+  implicit object ElectricChargeMassRatioNumeric extends AbstractQuantityNumeric[ElectricChargeMassRatio](ElectricChargeMassRatio.primaryUnit)
+}

--- a/shared/src/main/scala/squants/electro/LinearElectricChargeDensity.scala
+++ b/shared/src/main/scala/squants/electro/LinearElectricChargeDensity.scala
@@ -1,0 +1,49 @@
+package squants.electro
+
+import squants.space.Meters
+import squants.{AbstractQuantityNumeric, Dimension, Length, PrimaryUnit, Quantity, SiUnit, UnitConverter, UnitOfMeasure}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  * @param value Double
+  */
+final class LinearElectricChargeDensity private (val value: Double, val unit: LinearElectricChargeDensityUnit)
+  extends Quantity[LinearElectricChargeDensity] {
+
+  def dimension = LinearElectricChargeDensity
+
+  def *(that: Length): ElectricCharge = Coulombs(this.toCoulombsMeters * that.toMeters)
+  def /(that: Length): AreaElectricChargeDensity = CoulombsPerSquareMeter(this.toCoulombsMeters / that.toMeters)
+
+  def toCoulombsMeters = to(CoulombsPerMeter)
+}
+
+object LinearElectricChargeDensity extends Dimension[LinearElectricChargeDensity] {
+  private[electro] def apply[A](n: A, unit: LinearElectricChargeDensityUnit)(implicit num: Numeric[A]) = new LinearElectricChargeDensity(num.toDouble(n), unit)
+  def apply = parse _
+  def name = "LinearElectricChargeDensity"
+  def primaryUnit = CoulombsPerMeter
+  def siUnit = CoulombsPerMeter
+  def units = Set(CoulombsPerMeter)
+}
+
+trait LinearElectricChargeDensityUnit extends UnitOfMeasure[LinearElectricChargeDensity] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = LinearElectricChargeDensity(n, this)
+}
+
+object CoulombsPerMeter extends LinearElectricChargeDensityUnit with PrimaryUnit with SiUnit {
+  val symbol = Coulombs.symbol + "/" + Meters.symbol
+}
+
+object LinearElectricChargeDensityConversions {
+  lazy val coulombPerMeter = CoulombsPerMeter(1)
+
+  implicit class LinearElectricChargeDensityConversions[A](n: A)(implicit num: Numeric[A]) {
+    def coulombsPerMeter = CoulombsPerMeter(n)
+  }
+
+  implicit object LinearElectricChargeDensityNumeric extends AbstractQuantityNumeric[LinearElectricChargeDensity](LinearElectricChargeDensity.primaryUnit)
+}

--- a/shared/src/main/scala/squants/experimental/unitgroups/ImplicitDimensions.scala
+++ b/shared/src/main/scala/squants/experimental/unitgroups/ImplicitDimensions.scala
@@ -19,13 +19,17 @@ import squants.time.{Frequency, Time}
 object ImplicitDimensions {
 
   object electro {
+    implicit val implicitAreaElectricChargeDensity: Dimension[AreaElectricChargeDensity] = AreaElectricChargeDensity
     implicit val implicitCapacitance: Dimension[Capacitance] = Capacitance
     implicit val implicitConductivity: Dimension[Conductivity] = Conductivity
     implicit val implicitElectricalConductance: Dimension[ElectricalConductance] = ElectricalConductance
     implicit val implicitElectricalResistance: Dimension[ElectricalResistance] = ElectricalResistance
     implicit val implicitElectricCharge: Dimension[ElectricCharge] = ElectricCharge
+    implicit val implicitElectricChargeDensity: Dimension[ElectricChargeDensity] = ElectricChargeDensity
+    implicit val implicitElectricChargeMassRatio: Dimension[ElectricChargeMassRatio] = ElectricChargeMassRatio
     implicit val implicitElectricPotential: Dimension[ElectricPotential] = ElectricPotential
     implicit val implicitInductance: Dimension[Inductance] = Inductance
+    implicit val implicitLinearElectricChargeDensity: Dimension[LinearElectricChargeDensity] = LinearElectricChargeDensity
     implicit val implicitMagneticFlux: Dimension[MagneticFlux] = MagneticFlux
     implicit val implicitMagneticFluxDensity: Dimension[MagneticFluxDensity] = MagneticFluxDensity
     implicit val implicitResistivity: Dimension[Resistivity] = Resistivity

--- a/shared/src/test/scala/squants/electro/AreaElectricChargeDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/AreaElectricChargeDensitySpec.scala
@@ -1,0 +1,65 @@
+package squants.electro
+
+import org.scalatest.{FlatSpec, Matchers}
+import squants.QuantityParseException
+import squants.space.{Meters, SquareMeters}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  */
+class AreaElectricChargeDensitySpec extends FlatSpec with Matchers {
+
+  behavior of "AreaElectricChargeDensity and its Units of Measure"
+
+  it should "create values using UOM factories" in {
+    CoulombsPerSquareMeter(1).toCoulombsSquareMeters should be(1)
+  }
+
+  it should "create values from properly formatted Strings" in {
+    AreaElectricChargeDensity("10.22 C/m²").get should be(CoulombsPerSquareMeter(10.22))
+    AreaElectricChargeDensity("10.22 zz").failed.get should be(QuantityParseException("Unable to parse AreaElectricChargeDensity", "10.22 zz"))
+    AreaElectricChargeDensity("zz C/m²").failed.get should be(QuantityParseException("Unable to parse AreaElectricChargeDensity", "zz C/m²"))
+  }
+
+  it should "properly convert to all supported Units of Measure" in {
+    val x = CoulombsPerSquareMeter(10)
+    x.toCoulombsSquareMeters should be(10.0)
+  }
+
+  it should "return properly formatted strings for all supported Units of Measure" in {
+    CoulombsPerSquareMeter(1).toString(CoulombsPerSquareMeter) should be("1.0 C/m²")
+  }
+
+  it should "return ElectricCharge when multiplied by Area" in {
+    CoulombsPerSquareMeter(1) * SquareMeters(1) should be(Coulombs(1))
+  }
+
+  it should "return LinearElectricChargeDensity when multiplied by Length" in {
+    CoulombsPerSquareMeter(1) * Meters(1) should be(CoulombsPerMeter(1))
+  }
+
+  behavior of "AreaElectricChargeDensityConversions"
+
+  it should "provide aliases for single unit values" in {
+    import AreaElectricChargeDensityConversions._
+
+    coulombPerSquareMeter should be(CoulombsPerSquareMeter(1))
+  }
+
+  it should "provide implicit conversion from Double" in {
+    import AreaElectricChargeDensityConversions._
+
+    val d = 10.22
+    d.coulombsPerSquareMeter should be(CoulombsPerSquareMeter(d))
+  }
+
+  it should "provide Numeric support" in {
+    import AreaElectricChargeDensityConversions.AreaElectricChargeDensityNumeric
+
+    val rs = List(CoulombsPerSquareMeter(100), CoulombsPerSquareMeter(10))
+    rs.sum should be(CoulombsPerSquareMeter(110))
+  }
+}

--- a/shared/src/test/scala/squants/electro/ElectricChargeDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricChargeDensitySpec.scala
@@ -1,0 +1,69 @@
+package squants.electro
+
+import org.scalatest.{FlatSpec, Matchers}
+import squants.QuantityParseException
+import squants.space.{CubicMeters, Meters, SquareMeters}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  */
+class ElectricChargeDensitySpec extends FlatSpec with Matchers {
+
+  behavior of "ElectricChargeDensity and its Units of Measure"
+
+  it should "create values using UOM factories" in {
+    CoulombsPerCubicMeter(1).toCoulombsCubicMeters should be(1)
+  }
+
+  it should "create values from properly formatted Strings" in {
+    ElectricChargeDensity("10.22 C/m³").get should be(CoulombsPerCubicMeter(10.22))
+    ElectricChargeDensity("10.22 zz").failed.get should be(QuantityParseException("Unable to parse ElectricChargeDensity", "10.22 zz"))
+    ElectricChargeDensity("zz C/m³").failed.get should be(QuantityParseException("Unable to parse ElectricChargeDensity", "zz C/m³"))
+  }
+
+  it should "properly convert to all supported Units of Measure" in {
+    val x = CoulombsPerCubicMeter(10)
+    x.toCoulombsCubicMeters should be(10.0)
+  }
+
+  it should "return properly formatted strings for all supported Units of Measure" in {
+    CoulombsPerCubicMeter(1).toString(CoulombsPerCubicMeter) should be("1.0 C/m³")
+  }
+
+  it should "return ElectricCharge when multiplied by Volume" in {
+    CoulombsPerCubicMeter(1) * CubicMeters(1) should be(Coulombs(1))
+  }
+
+  it should "return LinearElectricChargeDensity when multiplied by Area" in {
+    CoulombsPerCubicMeter(1) * SquareMeters(1) should be(CoulombsPerMeter(1))
+  }
+
+  it should "return AreaElectricChargeDensity when multiplied by Length" in {
+    CoulombsPerCubicMeter(1) * Meters(1) should be(CoulombsPerSquareMeter(1))
+  }
+
+  behavior of "ElectricChargeDensityConversions"
+
+  it should "provide aliases for single unit values" in {
+    import ElectricChargeDensityConversions._
+
+    coulombPerCubicMeter should be(CoulombsPerCubicMeter(1))
+  }
+
+  it should "provide implicit conversion from Double" in {
+    import ElectricChargeDensityConversions._
+
+    val d = 10.22
+    d.coulombsPerCubicMeter should be(CoulombsPerCubicMeter(d))
+  }
+
+  it should "provide Numeric support" in {
+    import ElectricChargeDensityConversions.ElectricChargeDensityNumeric
+
+    val rs = List(CoulombsPerCubicMeter(100), CoulombsPerCubicMeter(10))
+    rs.sum should be(CoulombsPerCubicMeter(110))
+  }
+}

--- a/shared/src/test/scala/squants/electro/ElectricChargeMassRatioSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricChargeMassRatioSpec.scala
@@ -1,0 +1,62 @@
+package squants.electro
+
+import org.scalatest.{FlatSpec, Matchers}
+import squants.QuantityParseException
+import squants.mass.Kilograms
+import squants.space.{CubicMeters, Meters, SquareMeters}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  */
+class ElectricChargeMassRatioSpec extends FlatSpec with Matchers {
+
+  behavior of "ElectricChargeMassRatio and its Units of Measure"
+
+  it should "create values using UOM factories" in {
+    CoulombsPerKilogram(1).toCoulombsKilograms should be(1)
+  }
+
+  it should "create values from properly formatted Strings" in {
+    ElectricChargeMassRatio("10.22 C/kg").get should be(CoulombsPerKilogram(10.22))
+    ElectricChargeMassRatio("10.22 zz").failed.get should be(QuantityParseException("Unable to parse ElectricChargeMassRatio", "10.22 zz"))
+    ElectricChargeMassRatio("zz C/kg").failed.get should be(QuantityParseException("Unable to parse ElectricChargeMassRatio", "zz C/kg"))
+  }
+
+  it should "properly convert to all supported Units of Measure" in {
+    val x = CoulombsPerKilogram(10)
+    x.toCoulombsKilograms should be(10.0)
+  }
+
+  it should "return properly formatted strings for all supported Units of Measure" in {
+    CoulombsPerKilogram(1).toString(CoulombsPerKilogram) should be("1.0 C/kg")
+  }
+
+  it should "return ElectricCharge when multiplied by Mass" in {
+    CoulombsPerKilogram(1) * Kilograms(1) should be(Coulombs(1))
+  }
+
+  behavior of "ElectricChargeMassRatioConversions"
+
+  it should "provide aliases for single unit values" in {
+    import ElectricChargeMassRatioConversions._
+
+    coulombPerKilogram should be(CoulombsPerKilogram(1))
+  }
+
+  it should "provide implicit conversion from Double" in {
+    import ElectricChargeMassRatioConversions._
+
+    val d = 10.22
+    d.coulombsPerKilogram should be(CoulombsPerKilogram(d))
+  }
+
+  it should "provide Numeric support" in {
+    import ElectricChargeMassRatioConversions.ElectricChargeMassRatioNumeric
+
+    val rs = List(CoulombsPerKilogram(100), CoulombsPerKilogram(10))
+    rs.sum should be(CoulombsPerKilogram(110))
+  }
+}

--- a/shared/src/test/scala/squants/electro/LinearElectricChargeDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/LinearElectricChargeDensitySpec.scala
@@ -1,0 +1,65 @@
+package squants.electro
+
+import org.scalatest.{FlatSpec, Matchers}
+import squants.QuantityParseException
+import squants.space.{CubicMeters, Meters, SquareMeters}
+
+/**
+  *
+  * @author Nicolas Vinuesa
+  * @since 1.4
+  *
+  */
+class LinearElectricChargeDensitySpec extends FlatSpec with Matchers {
+
+  behavior of "LinearElectricChargeDensity and its Units of Measure"
+
+  it should "create values using UOM factories" in {
+    CoulombsPerMeter(1).toCoulombsMeters should be(1)
+  }
+
+  it should "create values from properly formatted Strings" in {
+    LinearElectricChargeDensity("10.22 C/m").get should be(CoulombsPerMeter(10.22))
+    LinearElectricChargeDensity("10.22 zz").failed.get should be(QuantityParseException("Unable to parse LinearElectricChargeDensity", "10.22 zz"))
+    LinearElectricChargeDensity("zz C/m").failed.get should be(QuantityParseException("Unable to parse LinearElectricChargeDensity", "zz C/m"))
+  }
+
+  it should "properly convert to all supported Units of Measure" in {
+    val x = CoulombsPerMeter(10)
+    x.toCoulombsMeters should be(10.0)
+  }
+
+  it should "return properly formatted strings for all supported Units of Measure" in {
+    CoulombsPerMeter(1).toString(CoulombsPerMeter) should be("1.0 C/m")
+  }
+
+  it should "return ElectricCharge when multiplied by Length" in {
+    CoulombsPerMeter(1) * Meters(1) should be(Coulombs(1))
+  }
+
+  it should "return AreaElectricChargeDensity when divided by Length" in {
+    CoulombsPerMeter(1) / Meters(1) should be(CoulombsPerSquareMeter(1))
+  }
+
+  behavior of "LinearElectricChargeDensityConversions"
+
+  it should "provide aliases for single unit values" in {
+    import LinearElectricChargeDensityConversions._
+
+    coulombPerMeter should be(CoulombsPerMeter(1))
+  }
+
+  it should "provide implicit conversion from Double" in {
+    import LinearElectricChargeDensityConversions._
+
+    val d = 10.22
+    d.coulombsPerMeter should be(CoulombsPerMeter(d))
+  }
+
+  it should "provide Numeric support" in {
+    import LinearElectricChargeDensityConversions.LinearElectricChargeDensityNumeric
+
+    val rs = List(CoulombsPerMeter(100), CoulombsPerMeter(10))
+    rs.sum should be(CoulombsPerMeter(110))
+  }
+}


### PR DESCRIPTION
This is the second PR concerning issue #252 .

In this pull request, four new types are added: AreaElectricChargeDensity, ElectricChargeDensity, ElectricChargeMassRatio and LinearElectricChargeDensity.

This new types are needed to implement some unimplemented functions in ElectricCharge.