### PR TITLE
Adds mass.AreaDensity UOM PoundsPerAcre

### DIFF
--- a/shared/src/main/scala/squants/mass/AreaDensity.scala
+++ b/shared/src/main/scala/squants/mass/AreaDensity.scala
@@ -26,6 +26,7 @@ final class AreaDensity private (val value: Double, val unit: AreaDensityUnit)
   def toKilogramsPerSquareMeter = to(KilogramsPerSquareMeter)
   def toGramsPerSquareCentimeter = to(GramsPerSquareCentimeter)
   def toKilogramsPerHectare = to(KilogramsPerHectare)
+  def toPoundsPerAcre = to(PoundsPerAcre)
 }
 
 /**
@@ -57,6 +58,12 @@ object KilogramsPerHectare extends AreaDensityUnit with UnitConverter {
 object GramsPerSquareCentimeter extends AreaDensityUnit with UnitConverter with SiUnit {
   val symbol = "g/cm²"
   val conversionFactor = (100*100d)/1000d
+}
+
+object PoundsPerAcre extends AreaDensityUnit with UnitConverter {
+  val symbol = "lbs/acre"
+  // see http://www.kylesconverter.com/area-density/pounds-per-acre-to-kilograms-per-hectare
+  val conversionFactor = 0.8921791216197014
 }
 
 object AreaDensityConversions {

--- a/shared/src/main/scala/squants/mass/AreaDensity.scala
+++ b/shared/src/main/scala/squants/mass/AreaDensity.scala
@@ -9,6 +9,7 @@
 package squants.mass
 
 import squants._
+import squants.space.{Acres, SquareMeters}
 
 /**
  * @author  garyKeorkunian
@@ -39,7 +40,7 @@ object AreaDensity extends Dimension[AreaDensity] {
   def name = "AreaDensity"
   def primaryUnit = KilogramsPerSquareMeter
   def siUnit = KilogramsPerSquareMeter
-  def units = Set(KilogramsPerSquareMeter, KilogramsPerHectare, GramsPerSquareCentimeter)
+  def units = Set(KilogramsPerSquareMeter, KilogramsPerHectare, GramsPerSquareCentimeter, PoundsPerAcre)
 }
 
 trait AreaDensityUnit extends UnitOfMeasure[AreaDensity] {
@@ -61,15 +62,18 @@ object GramsPerSquareCentimeter extends AreaDensityUnit with UnitConverter with 
 }
 
 object PoundsPerAcre extends AreaDensityUnit with UnitConverter {
-  val symbol = "lbs/acre"
-  // see http://www.kylesconverter.com/area-density/pounds-per-acre-to-kilograms-per-hectare
-  val conversionFactor = 0.8921791216197014
+  val symbol = s"${Pounds.symbol}/${Acres.symbol}"
+  // Base unit is kg/m^2
+  import squants.mass.MassConversions.{pound, kilogram}
+  import squants.space.AreaConversions.{acre, squareMeter}
+  val conversionFactor = (pound/kilogram) / (acre/squareMeter)
 }
 
 object AreaDensityConversions {
   lazy val kilogramPerSquareMeter = KilogramsPerSquareMeter(1)
   lazy val kilogramPerHectare = KilogramsPerHectare(1)
   lazy val gramPerSquareCentimeter = GramsPerSquareCentimeter(1)
+  lazy val poundsPerAcre = PoundsPerAcre(1)
 
   implicit class AreaDensityConversions[A](n: A)(implicit num: Numeric[A]) {
     def kilogramsPerSquareMeter = KilogramsPerSquareMeter(n)

--- a/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
+++ b/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
@@ -8,9 +8,9 @@
 
 package squants.mass
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
-import squants.space.{Hectares, SquareMeters}
+import squants.space.{Acres, Hectares, SquareMeters}
 
 /**
  * @author  garyKeorkunian
@@ -24,6 +24,7 @@ class AreaDensitySpec extends FlatSpec with Matchers {
   it should "create values using UOM factories" in {
     KilogramsPerSquareMeter(1).toKilogramsPerSquareMeter should be(1)
     KilogramsPerHectare(1).toKilogramsPerHectare should be(1)
+    PoundsPerAcre(1).toPoundsPerAcre should be(1)
     GramsPerSquareCentimeter(1).toGramsPerSquareCentimeter should be(1)
   }
 
@@ -32,6 +33,7 @@ class AreaDensitySpec extends FlatSpec with Matchers {
     AreaDensity("10.45 zz").failed.get should be(QuantityParseException("Unable to parse AreaDensity", "10.45 zz"))
     AreaDensity("zz kg/m²").failed.get should be(QuantityParseException("Unable to parse AreaDensity", "zz kg/m²"))
     AreaDensity("10.33 kg/hectare").get should be(KilogramsPerHectare(10.33))
+    AreaDensity("10.33 lb/acre").get should be(PoundsPerAcre(10.33))
     AreaDensity("10.19 g/cm²").get should be(GramsPerSquareCentimeter(10.19))
   }
 
@@ -39,18 +41,21 @@ class AreaDensitySpec extends FlatSpec with Matchers {
     val x = KilogramsPerSquareMeter(1)
     x.toKilogramsPerSquareMeter should be(1)
     x.toKilogramsPerHectare should be(1e4)
+    x.toPoundsPerAcre should be(8921.79 +- 0.01)
     x.toGramsPerSquareCentimeter should be(0.1)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
     KilogramsPerSquareMeter(1).toString should be("1.0 kg/m²")
     KilogramsPerHectare(1).toString should be("1.0 kg/hectare")
+    PoundsPerAcre(1).toString should be("1.0 lb/acre")
     GramsPerSquareCentimeter(1).toString should be("1.0 g/cm²")
   }
 
   it should "return Mass when multiplied by Volume" in {
     KilogramsPerSquareMeter(1) * SquareMeters(1) should be(Kilograms(1))
     KilogramsPerHectare(1) * Hectares(1) should be(Kilograms(1))
+    PoundsPerAcre(1) * Acres(1) should be(Pounds(1))
     GramsPerSquareCentimeter(1000) * SquareMeters(1e-4) should be(Kilograms(1))
   }
 
@@ -61,6 +66,7 @@ class AreaDensitySpec extends FlatSpec with Matchers {
 
     kilogramPerSquareMeter should be(KilogramsPerSquareMeter(1))
     kilogramPerHectare should be(KilogramsPerHectare(1))
+    poundsPerAcre should be(PoundsPerAcre(1))
     gramPerSquareCentimeter should be(GramsPerSquareCentimeter(1))
   }
 


### PR DESCRIPTION
This is a unit we're using at Cibo which wasn't availble. It's easy
enough to define it locally, but since it's valid general code I am
submitting it to Squants itself.