### PR TITLE
Add units of measure: mm/s (velocity), mm/s^2 (acceleration), ng (mass)

### DIFF
--- a/shared/src/main/scala/squants/mass/Mass.scala
+++ b/shared/src/main/scala/squants/mass/Mass.scala
@@ -47,6 +47,7 @@ final class Mass private (val value: Double, val unit: MassUnit)
     */
   def onRadius(radius: Length): MomentOfInertia = KilogramsMetersSquared(toKilograms * radius.squared.toSquareMeters)
 
+  def toNanograms = to(Nanograms)
   def toMicrograms = to(Micrograms)
   def toMilligrams = to(Milligrams)
   def toGrams = to(Grams)
@@ -84,8 +85,8 @@ object Mass extends Dimension[Mass] with BaseDimension {
   def name = "Mass"
   def primaryUnit = Grams
   def siUnit = Kilograms
-  def units = Set(Micrograms, Milligrams, Grams, Kilograms, Tonnes, Ounces, Pounds, Kilopounds, Megapounds, Stone,
-    TroyGrains, Pennyweights, TroyOunces, TroyPounds, Tolas, Carats, SolarMasses,
+  def units = Set(Nanograms, Micrograms, Milligrams, Grams, Kilograms, Tonnes, Ounces, Pounds, Kilopounds, Megapounds,
+    Stone, TroyGrains, Pennyweights, TroyOunces, TroyPounds, Tolas, Carats, SolarMasses,
     ElectronVoltMass, MilliElectronVoltMass, KiloElectronVoltMass, MegaElectronVoltMass,
     GigaElectronVoltMass, TeraElectronVoltMass, PetaElectronVoltMass, ExaElectronVoltMass)
   def dimensionSymbol = "M"
@@ -100,6 +101,11 @@ trait MassUnit extends UnitOfMeasure[Mass] with UnitConverter {
 
 object Grams extends MassUnit with PrimaryUnit with SiUnit {
   val symbol = "g"
+}
+
+object Nanograms extends MassUnit with SiUnit {
+  val conversionFactor = MetricSystem.Nano
+  val symbol = "ng"
 }
 
 object Micrograms extends MassUnit with SiUnit {
@@ -227,6 +233,7 @@ object ExaElectronVoltMass extends MassUnit {
  * Provides support fot the DSL
  */
 object MassConversions {
+  lazy val nanogram = Nanograms(1)
   lazy val microgram = Micrograms(1)
   lazy val milligram = Milligrams(1)
   lazy val gram = Grams(1)
@@ -255,7 +262,10 @@ object MassConversions {
   lazy val EeV = ExaElectronVoltMass(1)
 
   implicit class MassConversions[A](n: A)(implicit num: Numeric[A]) {
+    def ng = Nanograms(n)
+    def nanograms = ng
     def mcg = Micrograms(n)
+    def micrograms = mcg
     def mg = Milligrams(n)
     def milligrams = mg
     def g = Grams(n)

--- a/shared/src/main/scala/squants/motion/Acceleration.scala
+++ b/shared/src/main/scala/squants/motion/Acceleration.scala
@@ -9,7 +9,7 @@
 package squants.motion
 
 import squants._
-import squants.space.{ Feet, UsMiles }
+import squants.space.{ Feet, Millimeters, UsMiles }
 import squants.time.{ Seconds, _ }
 
 /**
@@ -36,6 +36,7 @@ final class Acceleration private (val value: Double, val unit: AccelerationUnit)
   def *(that: TimeSquared): Length = this * that.time1 * that.time2
 
   def toFeetPerSecondSquared = to(FeetPerSecondSquared)
+  def toMillimetersPerSecondSquared = to(MillimetersPerSecondSquared)
   def toMetersPerSecondSquared = to(MetersPerSecondSquared)
   def toUsMilesPerHourSquared = to(UsMilesPerHourSquared)
   def toEarthGravities = to(EarthGravities)
@@ -63,7 +64,8 @@ object Acceleration extends Dimension[Acceleration] {
   def name = "Acceleration"
   def primaryUnit = MetersPerSecondSquared
   def siUnit = MetersPerSecondSquared
-  def units = Set(FeetPerSecondSquared, MetersPerSecondSquared, UsMilesPerHourSquared, EarthGravities)
+  def units = Set(FeetPerSecondSquared, MillimetersPerSecondSquared, MetersPerSecondSquared, UsMilesPerHourSquared,
+    EarthGravities)
 }
 
 /**
@@ -75,6 +77,11 @@ object Acceleration extends Dimension[Acceleration] {
  */
 trait AccelerationUnit extends UnitOfMeasure[Acceleration] with UnitConverter {
   def apply[A](n: A)(implicit num: Numeric[A]) = Acceleration(n, this)
+}
+
+object MillimetersPerSecondSquared extends AccelerationUnit with SiUnit {
+  val symbol = "mm/s²"
+  val conversionFactor = Millimeters.conversionFactor / Meters.conversionFactor
 }
 
 object MetersPerSecondSquared extends AccelerationUnit with PrimaryUnit with SiUnit {

--- a/shared/src/main/scala/squants/motion/Velocity.scala
+++ b/shared/src/main/scala/squants/motion/Velocity.scala
@@ -9,7 +9,7 @@
 package squants.motion
 
 import squants.{ Time, _ }
-import squants.space.{ Feet, InternationalMiles, Kilometers, NauticalMiles, UsMiles }
+import squants.space.{ Feet, InternationalMiles, Kilometers, Millimeters, NauticalMiles, UsMiles }
 import squants.time.{ Seconds, _ }
 
 /**
@@ -38,6 +38,7 @@ final class Velocity private (val value: Double, val unit: VelocityUnit)
   def /(that: Jerk): TimeSquared = (this / that.timeIntegrated) * this.time
 
   def toFeetPerSecond = to(FeetPerSecond)
+  def toMillimetersPerSecond = to(MillimetersPerSecond)
   def toMetersPerSecond = to(MetersPerSecond)
   def toKilometersPerSecond = to(KilometersPerSecond)
   def toKilometersPerHour = to(KilometersPerHour)
@@ -53,8 +54,8 @@ object Velocity extends Dimension[Velocity] {
   def name = "Velocity"
   def primaryUnit = MetersPerSecond
   def siUnit = MetersPerSecond
-  def units = Set(MetersPerSecond, FeetPerSecond, KilometersPerSecond, KilometersPerHour, UsMilesPerHour,
-    InternationalMilesPerHour, Knots)
+  def units = Set(MetersPerSecond, FeetPerSecond, MillimetersPerSecond, KilometersPerSecond, KilometersPerHour,
+    UsMilesPerHour, InternationalMilesPerHour, Knots)
 }
 
 trait VelocityUnit extends UnitOfMeasure[Velocity] with UnitConverter {
@@ -64,6 +65,11 @@ trait VelocityUnit extends UnitOfMeasure[Velocity] with UnitConverter {
 object FeetPerSecond extends VelocityUnit {
   val symbol = "ft/s"
   val conversionFactor = Feet.conversionFactor * Meters.conversionFactor
+}
+
+object MillimetersPerSecond extends VelocityUnit with SiUnit {
+  val symbol = "mm/s"
+  val conversionFactor = Millimeters.conversionFactor / Meters.conversionFactor
 }
 
 object MetersPerSecond extends VelocityUnit with PrimaryUnit with SiUnit {
@@ -97,6 +103,7 @@ object Knots extends VelocityUnit {
 
 object VelocityConversions {
   lazy val footPerSecond = FeetPerSecond(1)
+  lazy val millimeterPerSecond = MillimetersPerSecond(1)
   lazy val meterPerSecond = MetersPerSecond(1)
   lazy val kilometerPerSecond = KilometersPerSecond(1)
   lazy val kilometerPerHour = KilometersPerHour(1)

--- a/shared/src/test/scala/squants/mass/MassSpec.scala
+++ b/shared/src/test/scala/squants/mass/MassSpec.scala
@@ -24,6 +24,7 @@ class MassSpec extends FlatSpec with Matchers {
   behavior of "Mass and its Units of Measure"
 
   it should "create values using UOM factories" in {
+    Nanograms(10.22).toNanograms should be(10.22)
     Micrograms(10.22).toMicrograms should be(10.22)
     Milligrams(10.22).toMilligrams should be(10.22)
     Grams(10.22).toGrams should be(10.22)
@@ -53,6 +54,7 @@ class MassSpec extends FlatSpec with Matchers {
   }
 
   it should "create values from properly formatted Strings" in {
+    Mass("10.22 ng").get should be(Nanograms(10.22))
     Mass("10.22 mcg").get should be(Micrograms(10.22))
     Mass("10.22 mg").get should be(Milligrams(10.22))
     Mass("10.22 g").get should be(Grams(10.22))
@@ -84,6 +86,7 @@ class MassSpec extends FlatSpec with Matchers {
 
   it should "properly convert to all supported Units of Measure" in {
     val x = Grams(1)
+    x.toNanograms should be(1 / MetricSystem.Nano)
     x.toMicrograms should be(1 / MetricSystem.Micro)
     x.toMilligrams should be(1 / MetricSystem.Milli)
     x.toGrams should be(1)
@@ -125,6 +128,7 @@ class MassSpec extends FlatSpec with Matchers {
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
+    Nanograms(1).toString(Nanograms) should be("1.0 ng")
     Micrograms(1).toString(Micrograms) should be("1.0 mcg")
     Milligrams(1).toString(Milligrams) should be("1.0 mg")
     Grams(1).toString(Grams) should be("1.0 g")
@@ -193,6 +197,7 @@ class MassSpec extends FlatSpec with Matchers {
   it should "provide aliases for single unit values" in {
     import MassConversions._
 
+    nanogram should be(Nanograms(1))
     microgram should be(Micrograms(1))
     milligram should be(Milligrams(1))
     gram should be(Grams(1))
@@ -224,7 +229,10 @@ class MassSpec extends FlatSpec with Matchers {
     import MassConversions._
 
     val d = 10.22
+    d.ng should be(Nanograms(d))
+    d.nanograms should be(Nanograms(d))
     d.mcg should be(Micrograms(d))
+    d.micrograms should be(Micrograms(d))
     d.mg should be(Milligrams(d))
     d.milligrams should be(Milligrams(d))
     d.g should be(Grams(d))
@@ -269,6 +277,7 @@ class MassSpec extends FlatSpec with Matchers {
   it should "provide implicit conversions from String" in {
     import MassConversions._
 
+    "10.45 ng".toMass.get should be(Nanograms(10.45))
     "10.45 mcg".toMass.get should be(Micrograms(10.45))
     "10.45 mg".toMass.get should be(Milligrams(10.45))
     "10.45 g".toMass.get should be(Grams(10.45))

--- a/shared/src/test/scala/squants/motion/AccelerationSpec.scala
+++ b/shared/src/test/scala/squants/motion/AccelerationSpec.scala
@@ -24,6 +24,7 @@ class AccelerationSpec extends FlatSpec with Matchers {
   behavior of "Acceleration and its Units of Measure"
 
   it should "create values using UOM factories" in {
+    MillimetersPerSecondSquared(1).toMillimetersPerSecondSquared should be(1)
     MetersPerSecondSquared(1).toMetersPerSecondSquared should be(1)
     FeetPerSecondSquared(1).toFeetPerSecondSquared should be(1)
     UsMilesPerHourSquared(1).toUsMilesPerHourSquared should be(1)
@@ -31,6 +32,7 @@ class AccelerationSpec extends FlatSpec with Matchers {
   }
 
   it should "create values from properly formatted Strings" in {
+    Acceleration("10.22 mm/s²").get should be(MillimetersPerSecondSquared(10.22))
     Acceleration("10.22 m/s²").get should be(MetersPerSecondSquared(10.22))
     Acceleration("10.22 ft/s²").get should be(FeetPerSecondSquared(10.22))
     Acceleration("10.22 mph²").get should be(UsMilesPerHourSquared(10.22))
@@ -43,12 +45,14 @@ class AccelerationSpec extends FlatSpec with Matchers {
     val x = MetersPerSecondSquared(1)
     x.toMetersPerSecondSquared should be(1)
     x.toFeetPerSecondSquared should be(Meters(1).toFeet)
+    x.toMillimetersPerSecondSquared should be(Meters(1).toMillimeters)
     x.toUsMilesPerHourSquared should be(Meters(1).toUsMiles / (Seconds(1).toHours * Seconds(1).toHours))
     x.toEarthGravities should be(1d / squants.motion.StandardEarthGravity.toMetersPerSecondSquared)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
     MetersPerSecondSquared(1).toString(MetersPerSecondSquared) should be("1.0 m/s²")
+    MillimetersPerSecondSquared(1).toString(MillimetersPerSecondSquared) should be("1.0 mm/s²")
     FeetPerSecondSquared(1).toString(FeetPerSecondSquared) should be("1.0 ft/s²")
     UsMilesPerHourSquared(1).toString(UsMilesPerHourSquared) should be("1.0 mph²")
     EarthGravities(1).toString(EarthGravities) should be("1.0 g")

--- a/shared/src/test/scala/squants/motion/VelocitySpec.scala
+++ b/shared/src/test/scala/squants/motion/VelocitySpec.scala
@@ -26,6 +26,7 @@ class VelocitySpec extends FlatSpec with Matchers {
   it should "create values using UOM factories" in {
     MetersPerSecond(1).toMetersPerSecond should be(1)
     FeetPerSecond(1).toFeetPerSecond should be(1)
+    MillimetersPerSecond(1).toMillimetersPerSecond should be(1)
     KilometersPerSecond(1).toKilometersPerSecond should be(1)
     KilometersPerHour(1).toKilometersPerHour should be(1)
     UsMilesPerHour(1).toUsMilesPerHour should be(1)
@@ -35,6 +36,7 @@ class VelocitySpec extends FlatSpec with Matchers {
   it should "create values from properly formatted Strings" in {
     Velocity("10.22 m/s").get should be(MetersPerSecond(10.22))
     Velocity("10.22 ft/s").get should be(FeetPerSecond(10.22))
+    Velocity("10.22 mm/s").get should be(MillimetersPerSecond(10.22))
     Velocity("10.22 km/s").get should be(KilometersPerSecond(10.22))
     Velocity("10.22 km/h").get should be(KilometersPerHour(10.22))
     Velocity("10.22 mph").get should be(UsMilesPerHour(10.22))
@@ -47,6 +49,8 @@ class VelocitySpec extends FlatSpec with Matchers {
     val x = MetersPerSecond(1)
     x.toMetersPerSecond should be(1)
     x.toFeetPerSecond should be(Meters(1).toFeet)
+    x.toMillimetersPerSecond should be(Meters(1).toMillimeters)
+    x.toKilometersPerSecond should be(Meters(1).toKilometers)
     x.toKilometersPerHour should be(Meters(1).toKilometers / Seconds(1).toHours +- tolerance)
     x.toUsMilesPerHour should be(Meters(1).toUsMiles / Seconds(1).toHours +- tolerance)
     x.toInternationalMilesPerHour should be(Meters(1).toInternationalMiles / Seconds(1).toHours +- tolerance)
@@ -56,6 +60,7 @@ class VelocitySpec extends FlatSpec with Matchers {
   it should "return properly formatted strings for all supported Units of Measure" in {
     MetersPerSecond(1).toString(MetersPerSecond) should be("1.0 m/s")
     FeetPerSecond(1).toString(FeetPerSecond) should be("1.0 ft/s")
+    MillimetersPerSecond(1).toString(MillimetersPerSecond) should be("1.0 mm/s")
     KilometersPerSecond(1).toString(KilometersPerSecond) should be("1.0 km/s")
     KilometersPerHour(1).toString(KilometersPerHour) should be("1.0 km/h")
     UsMilesPerHour(1).toString(UsMilesPerHour) should be("1.0 mph")
@@ -86,6 +91,7 @@ class VelocitySpec extends FlatSpec with Matchers {
 
     meterPerSecond should be(MetersPerSecond(1))
     footPerSecond should be(FeetPerSecond(1))
+    millimeterPerSecond should be(MillimetersPerSecond(1))
     kilometerPerSecond should be(KilometersPerSecond(1))
     kilometerPerHour should be(KilometersPerHour(1))
     milePerHour should be(UsMilesPerHour(1))


### PR DESCRIPTION
These units give the next smaller SI prefix than what is currently available for velocity, acceleration, and mass.