### PR TITLE
Make Dimension.parse public

### DIFF
--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -55,7 +55,7 @@ trait Dimension[A <: Quantity[A]] {
    * @param value the source string (ie, "10 kW") or tuple (ie, (10, "kW"))
    * @return Try[A]
    */
-  protected def parse(value: Any) = value match {
+  def parse(value: Any): Try[A] = value match {
     case s: String              => parseString(s)
     case (v: Byte, u: String)   => parseTuple(v.toDouble, u)
     case (v: Short, u: String)  => parseTuple(v.toDouble, u)

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -8,11 +8,12 @@
 
 package squants
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
+
 import scala.math.BigDecimal.RoundingMode
-import scala.util.Failure
-import squants.thermal.{ Celsius, Fahrenheit }
-import squants.time.{ Hertz, Hours }
+import scala.util.{Failure, Try}
+import squants.thermal.{Celsius, Fahrenheit}
+import squants.time.{Hertz, Hours, Minutes}
 
 /**
  * @author  garyKeorkunian
@@ -604,5 +605,57 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
 
     val ts = List(Thangs(1000), Kilothangs(10), Kilothangs(100))
     ts.sum should be(Kilothangs(111))
+  }
+
+  behavior of "Dimension"
+
+  it should "Parse a String into a Quantity based on the supplied Type parameter" in {
+    import squants.mass.Mass
+    import squants.space.Length
+    import squants.time.Time
+
+    def parse[A <: Quantity[A]: Dimension](s: String): Try[A] = {
+      implicitly[Dimension[A]].parse(s)
+    }
+
+    implicit val length = Length
+    implicit val time = Time
+    implicit val thingee = Thingee
+    implicit val mass = Mass
+
+    val l = parse[Length]("100 m")
+    val t = parse[Time]("100 m")
+    val th = parse[Thingee]("100 th")
+    val m = parse[Mass]("100 m")
+
+    l.get should be(Meters(100))
+    t.get should be(Minutes(100))
+    th.get should be(Thangs(100))
+    m.isFailure should be(true)
+  }
+
+  it should "Parse a Tuple into a Quantity based on the supplied Type parameter" in {
+    import squants.mass.Mass
+    import squants.space.Length
+    import squants.time.Time
+
+    def parse[A <: Quantity[A]: Dimension](t: (Double,  String)): Try[A] = {
+      implicitly[Dimension[A]].parse(t)
+    }
+
+    implicit val length = Length
+    implicit val time = Time
+    implicit val thingee = Thingee
+    implicit val mass = Mass
+
+    val l = parse[Length]((100, "m"))
+    val t = parse[Time]((100, "m"))
+    val th = parse[Thingee]((100, "th"))
+    val m = parse[Mass]((100, "m"))
+
+    l.get should be(Meters(100))
+    t.get should be(Minutes(100))
+    th.get should be(Thangs(100d))
+    m.isFailure should be(true)
   }
 }


### PR DESCRIPTION
This change is at the request of developers of companion libraries.

Making `Dimension.parse` public enable these libraries to integrate more abstractly, preventing the need to code for each Quantity type.