### PR TITLE
Make Dimension.parseString/Tuple public

### DIFF
--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -56,13 +56,14 @@ trait Dimension[A <: Quantity[A]] {
    * @return Try[A]
    */
   protected def parse(value: Any): Try[A] = value match {
-    case s: String              => parseString(s)
-    case (v: Byte, u: String)   => parseTuple((v, u))
-    case (v: Short, u: String)  => parseTuple((v, u))
-    case (v: Int, u: String)    => parseTuple((v, u))
-    case (v: Long, u: String)   => parseTuple((v, u))
-    case (v: Float, u: String)  => parseTuple((v, u))
-    case (v: Double, u: String) => parseTuple((v, u))
+    case s: String              ⇒ parseString(s)
+    case (v: Byte, u: String)   ⇒ parseTuple((v, u))
+    case (v: Short, u: String)  ⇒ parseTuple((v, u))
+    case (v: Int, u: String)    ⇒ parseTuple((v, u))
+    case (v: Long, u: String)   ⇒ parseTuple((v, u))
+    case (v: Float, u: String)  ⇒ parseTuple((v, u))
+    case (v: Double, u: String) ⇒ parseTuple((v, u))
+    case _ ⇒ Failure(QuantityParseException(s"Unable to parse $name", value.toString))
   }
 
   def parseString(s: String): Try[A] = {
@@ -73,15 +74,15 @@ trait Dimension[A <: Quantity[A]] {
   }
   private lazy val QuantityString = ("^([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?) *(" + units.map { u: UnitOfMeasure[A] ⇒ u.symbol }.reduceLeft(_ + "|" + _) + ")$").r
 
-  def parseTuple[N: Numeric](t: (N, String)): Try[A] = {
+  def parseTuple[N](t: (N, String))(implicit num: Numeric[N]): Try[A] = {
     symbolToUnit(t._2) match {
       case Some(unit) ⇒ Success(unit(t._1))
-      case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit ${t._2}", (t._1, t._2).toString()))
+      case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit ${t._2}", s"(${Platform.crossFormat(num.toDouble(t._1))},${t._2})"))
     }
   }
 }
 
-case class QuantityParseException(message: String, expression: String) extends Exception
+case class QuantityParseException(message: String, expression: String) extends Exception(message + ":" + expression)
 
 /**
  * SI Base Quantity

--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -55,18 +55,17 @@ trait Dimension[A <: Quantity[A]] {
    * @param value the source string (ie, "10 kW") or tuple (ie, (10, "kW"))
    * @return Try[A]
    */
-  protected def parse(value: Any) = value match {
+  protected def parse(value: Any): Try[A] = value match {
     case s: String              => parseString(s)
-    case (v: Byte, u: String)   => parseTuple(v.toDouble, u)
-    case (v: Short, u: String)  => parseTuple(v.toDouble, u)
-    case (v: Int, u: String)    => parseTuple(v.toDouble, u)
-    case (v: Long, u: String)   => parseTuple(v.toDouble, u)
-    case (v: Float, u: String)  => parseTuple(v.toDouble, u)
-    case (v: Double, u: String) => parseTuple(v, u)
+    case (v: Byte, u: String)   => parseTuple((v, u))
+    case (v: Short, u: String)  => parseTuple((v, u))
+    case (v: Int, u: String)    => parseTuple((v, u))
+    case (v: Long, u: String)   => parseTuple((v, u))
+    case (v: Float, u: String)  => parseTuple((v, u))
+    case (v: Double, u: String) => parseTuple((v, u))
   }
 
-
-  private def parseString(s: String): Try[A] = {
+  def parseString(s: String): Try[A] = {
     s match {
       case QuantityString(value, symbol) ⇒ Success(symbolToUnit(symbol).get(BigDecimal(value)))
       case _                             ⇒ Failure(QuantityParseException(s"Unable to parse $name", s))
@@ -74,10 +73,10 @@ trait Dimension[A <: Quantity[A]] {
   }
   private lazy val QuantityString = ("^([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?) *(" + units.map { u: UnitOfMeasure[A] ⇒ u.symbol }.reduceLeft(_ + "|" + _) + ")$").r
 
-  private def parseTuple(value: Double, symbol: String): Try[A] = {
-    symbolToUnit(symbol) match {
-      case Some(unit) ⇒ Success(unit(value))
-      case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit $symbol", (value, symbol).toString()))
+  def parseTuple[N: Numeric](t: (N, String)): Try[A] = {
+    symbolToUnit(t._2) match {
+      case Some(unit) ⇒ Success(unit(t._1))
+      case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit ${t._2}", (t._1, t._2).toString()))
     }
   }
 }

--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -75,14 +75,16 @@ trait Dimension[A <: Quantity[A]] {
   private lazy val QuantityString = ("^([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?) *(" + units.map { u: UnitOfMeasure[A] ⇒ u.symbol }.reduceLeft(_ + "|" + _) + ")$").r
 
   def parseTuple[N](t: (N, String))(implicit num: Numeric[N]): Try[A] = {
-    symbolToUnit(t._2) match {
-      case Some(unit) ⇒ Success(unit(t._1))
-      case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit ${t._2}", s"(${Platform.crossFormat(num.toDouble(t._1))},${t._2})"))
+    val value = t._1
+    val symbol = t._2
+    symbolToUnit(symbol) match {
+      case Some(unit) ⇒ Success(unit(value))
+      case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit ${symbol}", s"(${Platform.crossFormat(num.toDouble(value))},${symbol})"))
     }
   }
 }
 
-case class QuantityParseException(message: String, expression: String) extends Exception(message + ":" + expression)
+case class QuantityParseException(message: String, expression: String) extends Exception(s"$message:$expression")
 
 /**
  * SI Base Quantity

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -8,7 +8,7 @@
 
 package squants
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers, TryValues}
 
 import scala.math.BigDecimal.RoundingMode
 import scala.util.{Failure, Try}
@@ -20,7 +20,7 @@ import squants.time.{Hertz, Hours, Minutes}
  * @since   0.1
  *
  */
-class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
+class QuantitySpec extends FlatSpec with Matchers with CustomMatchers with TryValues {
 
   /*
     Create a Quantity with two Units of Measure
@@ -628,10 +628,11 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
     val th = parse[Thingee]("100 th")
     val m = parse[Mass]("100 m")
 
-    l.get should be(Meters(100))
-    t.get should be(Minutes(100))
-    th.get should be(Thangs(100))
-    m.isFailure should be(true)
+    l.success.value should be(Meters(100))
+    t.success.value should be(Minutes(100))
+    th.success.value should be(Thangs(100))
+    m.failure.exception shouldBe a[QuantityParseException]
+    m.failure.exception should have message("Unable to parse Mass:100 m")
   }
 
   it should "Parse a Tuple with a Double into a Quantity based on the supplied Type parameter" in {
@@ -653,10 +654,11 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
     val th = parse[Thingee]((100d, "th"))
     val m = parse[Mass]((100d, "m"))
 
-    l.get should be(Meters(100d))
-    t.get should be(Minutes(100d))
-    th.get should be(Thangs(100d))
-    m.isFailure should be(true)
+    l.success.value should be(Meters(100d))
+    t.success.value should be(Minutes(100d))
+    th.success.value should be(Thangs(100d))
+    m.failure.exception shouldBe a[QuantityParseException]
+    m.failure.exception should have message("Unable to identify Mass unit m:(100.0,m)")
   }
 
   it should "Parse a Tuple with an Int into a Quantity based on the supplied Type parameter" in {
@@ -678,9 +680,10 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
     val th = parse[Thingee]((100, "th"))
     val m = parse[Mass]((100, "m"))
 
-    l.get should be(Meters(100))
-    t.get should be(Minutes(100))
-    th.get should be(Thangs(100))
-    m.isFailure should be(true)
+    l.success.value should be(Meters(100))
+    t.success.value should be(Minutes(100))
+    th.success.value should be(Thangs(100))
+    m.failure.exception shouldBe a[QuantityParseException]
+    m.failure.exception should have message("Unable to identify Mass unit m:(100.0,m)")
   }
 }

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -8,11 +8,12 @@
 
 package squants
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
+
 import scala.math.BigDecimal.RoundingMode
-import scala.util.Failure
-import squants.thermal.{ Celsius, Fahrenheit }
-import squants.time.{ Hertz, Hours }
+import scala.util.{Failure, Try}
+import squants.thermal.{Celsius, Fahrenheit}
+import squants.time.{Hertz, Hours, Minutes}
 
 /**
  * @author  garyKeorkunian
@@ -604,5 +605,82 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers {
 
     val ts = List(Thangs(1000), Kilothangs(10), Kilothangs(100))
     ts.sum should be(Kilothangs(111))
+  }
+
+  behavior of "Dimension"
+
+  it should "Parse a String into a Quantity based on the supplied Type parameter" in {
+    import squants.mass.Mass
+    import squants.space.Length
+    import squants.time.Time
+
+    def parse[A <: Quantity[A]: Dimension](s: String): Try[A] = {
+      implicitly[Dimension[A]].parseString(s)
+    }
+
+    implicit val length = Length
+    implicit val time = Time
+    implicit val thingee = Thingee
+    implicit val mass = Mass
+
+    val l = parse[Length]("100 m")
+    val t = parse[Time]("100 m")
+    val th = parse[Thingee]("100 th")
+    val m = parse[Mass]("100 m")
+
+    l.get should be(Meters(100))
+    t.get should be(Minutes(100))
+    th.get should be(Thangs(100))
+    m.isFailure should be(true)
+  }
+
+  it should "Parse a Tuple with a Double into a Quantity based on the supplied Type parameter" in {
+    import squants.mass.Mass
+    import squants.space.Length
+    import squants.time.Time
+
+    def parse[A <: Quantity[A]: Dimension](t: (Double,  String)): Try[A] = {
+      implicitly[Dimension[A]].parseTuple[Double](t)
+    }
+
+    implicit val length = Length
+    implicit val time = Time
+    implicit val thingee = Thingee
+    implicit val mass = Mass
+
+    val l = parse[Length]((100d, "m"))
+    val t = parse[Time]((100d, "m"))
+    val th = parse[Thingee]((100d, "th"))
+    val m = parse[Mass]((100d, "m"))
+
+    l.get should be(Meters(100d))
+    t.get should be(Minutes(100d))
+    th.get should be(Thangs(100d))
+    m.isFailure should be(true)
+  }
+
+  it should "Parse a Tuple with an Int into a Quantity based on the supplied Type parameter" in {
+    import squants.mass.Mass
+    import squants.space.Length
+    import squants.time.Time
+
+    def parse[A <: Quantity[A]: Dimension](t: (Int,  String)): Try[A] = {
+      implicitly[Dimension[A]].parseTuple[Int](t)
+    }
+
+    implicit val length = Length
+    implicit val time = Time
+    implicit val thingee = Thingee
+    implicit val mass = Mass
+
+    val l = parse[Length]((100, "m"))
+    val t = parse[Time]((100, "m"))
+    val th = parse[Thingee]((100, "th"))
+    val m = parse[Mass]((100, "m"))
+
+    l.get should be(Meters(100))
+    t.get should be(Minutes(100))
+    th.get should be(Thangs(100))
+    m.isFailure should be(true)
   }
 }


### PR DESCRIPTION
This change is at the request of developers of companion libraries.

Making `Dimension.parseString` and `Dimension.parseTuple` public to enable these libraries to integrate more abstractly, preventing the need to code for each Quantity type.

This change also updates `parseTuple` to use any Numeric instead of just Double.

The signature of the `parse` method proper is being left as is and protected.  Refactoring and exposing this method will break existing Dimension implementations and is, therefore, being deferred for now.