### PR TITLE
Use money context currencies when parsing a string

### DIFF
--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -392,10 +392,10 @@ object Money extends Dimension[Money] {
   def apply[A](n: A, currency: Currency)(implicit num: Numeric[A]) = new Money(BigDecimal(num.toDouble(n)))(currency)
   def apply[A](n: A, currency: String)(implicit num: Numeric[A]) = new Money(BigDecimal(num.toDouble(n)))(defaultCurrencyMap(currency))
 
-  def apply(s: String): Try[Money] = {
-    lazy val regex = ("([-+]?[0-9]*\\.?[0-9]+) *(" + defaultCurrencySet.map(_.code).reduceLeft(_ + "|" + _) + ")").r
+  def apply(s: String)(implicit moneyContext: MoneyContext): Try[Money] = {
+    lazy val regex = ("([-+]?[0-9]*\\.?[0-9]+) *(" + moneyContext.currencies.map(_.code).reduceLeft(_ + "|" + _) + ")").r
     s match {
-      case regex(value, currency) ⇒ Success(Money(value.toDouble, defaultCurrencyMap(currency)))
+      case regex(value, currencyStr) ⇒ Success(Money(value.toDouble, moneyContext.currencyMap(currencyStr)))
       case _                      ⇒ Failure(QuantityParseException("Unable to parse Money", s))
     }
   }

--- a/shared/src/main/scala/squants/market/MoneyContext.scala
+++ b/shared/src/main/scala/squants/market/MoneyContext.scala
@@ -35,6 +35,12 @@ case class MoneyContext(
     allowIndirectConversions: Boolean = true) {
 
   /**
+    * Support looking up currencies from a context
+    */
+  lazy val currencyMap: Map[String, Currency] = currencies.map { c: Currency ⇒ c.code -> c }.toMap
+
+
+  /**
     * Custom implementation using SortedSets to ensure consistent output
     * @return String representation of this instance
     */

--- a/shared/src/main/scala/squants/market/package.scala
+++ b/shared/src/main/scala/squants/market/package.scala
@@ -63,9 +63,13 @@ package object market {
     RUB, SEK, XAG, XAU, BTC,
     ETH, LTC, ZAR, NAD)
 
-  lazy val defaultCurrencyMap: Map[String, Currency] = defaultCurrencySet.map { c: Currency ⇒ c.code -> c }.toMap
 
   lazy val defaultMoneyContext = MoneyContext(USD, defaultCurrencySet, Nil)
+
+  /**
+    * Use currencyMap on MoneyContext
+    */
+  lazy val defaultCurrencyMap: Map[String, Currency] =  defaultMoneyContext.currencyMap
 
   class NoSuchExchangeRateException(val s: String) extends Exception
 }

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -47,6 +47,7 @@ class MoneySpec extends FlatSpec with Matchers {
   }
 
   it should "create values from formatted strings" in {
+    implicit val moneyContext = defaultMoneyContext
     Money("500 USD").get should be(USD(500))
     Money("500USD").get should be(USD(500))
     Money("5.50USD").get should be(USD(5.5))


### PR DESCRIPTION
This patch adds support for parsing strings including additional
currencies from the moneycontext.

```scala
  import squants.market.{Currency, Money, MoneyContext}
  object KES extends Currency("KES", "Kenyan Shillings", "KES", 0)
  implicit val moneyContext: MoneyContext = MoneyContext(KES, defaultCurrencySet, Nil)

  Money("100 KES")
```