### PR TITLE
Add a regression test for #311

### DIFF
--- a/shared/src/test/scala/squants/market/PriceSpec.scala
+++ b/shared/src/test/scala/squants/market/PriceSpec.scala
@@ -71,6 +71,11 @@ class PriceSpec extends FlatSpec with Matchers {
     (p1 / p2).toDouble should be(3)
   }
 
+  it should "properly multiply by Quantity using BigDecimal arithmetic" in {
+    val p1 = Price(Money(BigDecimal("0.3"), "USD"), Meters(1))
+    p1 * Meters(3) should be(Money(BigDecimal("0.9"), "USD"))
+  }
+
   it should "return Money when multiplied by Quantity" in {
     val p = Price(Money(10, "USD"), Meters(1))
     p * Meters(10) should be(Money(100, "USD"))


### PR DESCRIPTION
In v1.3.0 multiplying Price by a quantity would use the Money.value instead of Money.amount, which would cause problems if the Double representation of the amount wasn't exact.
I am adding this test to document the issue #311 resolution and make sure it stays fixed.