### PR TITLE
Inches of Mercury unit of Pressure

### DIFF
--- a/shared/src/main/scala/squants/motion/Pressure.scala
+++ b/shared/src/main/scala/squants/motion/Pressure.scala
@@ -35,6 +35,7 @@ final class Pressure private (val value: Double, val unit: PressureUnit)
   def toPoundsPerSquareInch: Double  = to(PoundsPerSquareInch)
   def toStandardAtmospheres: Double  = to(StandardAtmospheres)
   def toMillimetersOfMercury: Double = to(MillimetersOfMercury)
+  def toInchesOfMercury: Double       = to(InchesOfMercury)
   def toTorr: Double                 = to(Torrs)
 }
 
@@ -44,7 +45,7 @@ object Pressure extends Dimension[Pressure] {
   def name = "Pressure"
   def primaryUnit = Pascals
   def siUnit = Pascals
-  def units = Set(Pascals, Bars, PoundsPerSquareInch, StandardAtmospheres, MillimetersOfMercury, Torrs)
+  def units = Set(Pascals, Bars, PoundsPerSquareInch, StandardAtmospheres, MillimetersOfMercury, InchesOfMercury, Torrs)
 }
 
 trait PressureUnit extends UnitOfMeasure[Pressure] with UnitConverter {
@@ -75,6 +76,11 @@ object MillimetersOfMercury extends PressureUnit {
   val conversionFactor = Newtons.conversionFactor * 133.322387415
 }
 
+object InchesOfMercury extends PressureUnit {
+  val symbol = "inHg"
+  val conversionFactor = Newtons.conversionFactor * 3386.389
+}
+
 object Torrs extends PressureUnit {
   val symbol = "Torr"
   val conversionFactor = StandardAtmospheres.conversionFactor / 760d
@@ -86,6 +92,7 @@ object PressureConversions {
   lazy val psi    = PoundsPerSquareInch(1)
   lazy val atm    = StandardAtmospheres(1)
   lazy val mmHg   = MillimetersOfMercury(1)
+  lazy val inHg   = InchesOfMercury(1)
   lazy val torr   = Torrs(1)
 
   implicit class PressureConversions[A](n: A)(implicit num: Numeric[A]) {
@@ -94,6 +101,7 @@ object PressureConversions {
     def psi     = PoundsPerSquareInch(n)
     def atm     = StandardAtmospheres(n)
     def mmHg    = MillimetersOfMercury(n)
+    def inHg    = InchesOfMercury(n)
     def torr    = Torrs(n)
   }
 

--- a/shared/src/test/scala/squants/motion/PressureSpec.scala
+++ b/shared/src/test/scala/squants/motion/PressureSpec.scala
@@ -27,6 +27,7 @@ class PressureSpec extends FlatSpec with Matchers {
     PoundsPerSquareInch(1).toPoundsPerSquareInch should be(1)
     StandardAtmospheres(1).toStandardAtmospheres should be(1)
     MillimetersOfMercury(1).toMillimetersOfMercury should be(1)
+    InchesOfMercury(1).toInchesOfMercury should be(1)
     Torrs(1).toTorr should be(1)
   }
 
@@ -35,6 +36,7 @@ class PressureSpec extends FlatSpec with Matchers {
     Pressure("10.22 bar").get should be(Bars(10.22))
     Pressure("10.22 psi").get should be(PoundsPerSquareInch(10.22))
     Pressure("10.22 mmHg").get should be(MillimetersOfMercury(10.22))
+    Pressure("10.22 inHg").get should be(InchesOfMercury(10.22))
     Pressure("10.22 Torr").get should be(Torrs(10.22))
     Pressure("10.22 zz").failed.get should be(QuantityParseException("Unable to parse Pressure", "10.22 zz"))
     Pressure("zz Pa").failed.get should be(QuantityParseException("Unable to parse Pressure", "zz Pa"))
@@ -48,6 +50,7 @@ class PressureSpec extends FlatSpec with Matchers {
     x.toPoundsPerSquareInch should be(Newtons(1).toPoundForce / SquareMeters(1).toSquareInches +- tolerance)
     x.toStandardAtmospheres should be(1d / 101325d)
     x.toMillimetersOfMercury should be(1d / 133.322387415d)
+    x.toInchesOfMercury should be(1d / 3386.389)
     x.toTorr should be(760d / 101325d)
   }
 
@@ -57,6 +60,7 @@ class PressureSpec extends FlatSpec with Matchers {
     PoundsPerSquareInch(1).toString(PoundsPerSquareInch) should be("1.0 psi")
     StandardAtmospheres(1).toString(StandardAtmospheres) should be("1.0 atm")
     MillimetersOfMercury(1).toString(MillimetersOfMercury) should be("1.0 mmHg")
+    InchesOfMercury(1).toString(InchesOfMercury) should be("1.0 inHg")
     Torrs(1).toString(Torrs) should be("1.0 Torr")
   }
 
@@ -74,6 +78,7 @@ class PressureSpec extends FlatSpec with Matchers {
     psi should be(PoundsPerSquareInch(1))
     atm should be(StandardAtmospheres(1))
     mmHg should be(MillimetersOfMercury(1))
+    inHg should be(InchesOfMercury(1))
     torr should be(Torrs(1))
   }
   it should "provide implicit conversion from Double" in {
@@ -85,6 +90,7 @@ class PressureSpec extends FlatSpec with Matchers {
     d.psi should be(PoundsPerSquareInch(d))
     d.atm should be(StandardAtmospheres(d))
     d.mmHg should be(MillimetersOfMercury(d))
+    d.inHg should be(InchesOfMercury(d))
     d.torr should be(Torrs(d))
   }
 


### PR DESCRIPTION
I added the unit in Pressure and extended the unit tests. 

The conversion factor is as published in: 
Barry N. Taylor, Guide for the Use of the International System of Units (SI), 1995, 
NIST Special Publication 811, Appendix B
Online: https://www.nist.gov/physical-measurement-laboratory/nist-guide-si-appendix-b8

This pressure unit is commonly used in aviation, for example: In the altimeter setting and in weather reports called METARs. 