### PR TITLE
Add support for {Gibi|Mebi|Kilo|etc}bits (#304)

### DIFF
--- a/shared/src/main/scala/squants/information/DataRate.scala
+++ b/shared/src/main/scala/squants/information/DataRate.scala
@@ -4,7 +4,7 @@ import squants._
 import squants.time.TimeDerivative
 
 /**
-  * Represnets a rate of transfer of information
+  * Represents a rate of transfer of information
   */
 final class DataRate private(val value: Double, val unit: DataRateUnit)
     extends Quantity[DataRate]
@@ -32,6 +32,25 @@ final class DataRate private(val value: Double, val unit: DataRateUnit)
   def toExbibytesPerSecond = to(ExbibytesPerSecond)
   def toZebibytesPerSecond = to(ZebibytesPerSecond)
   def toYobibytesPerSecond = to(YobibytesPerSecond)
+
+  def toBitsPerSecond = to(BitsPerSecond)
+  def toKilobitsPerSecond = to(KilobitsPerSecond)
+  def toMegabitsPerSecond = to(MegabitsPerSecond)
+  def toGigabitsPerSecond = to(GigabitsPerSecond)
+  def toTerabitsPerSecond = to(TerabitsPerSecond)
+  def toPetabitsPerSecond = to(PetabitsPerSecond)
+  def toExabitsPerSecond = to(ExabitsPerSecond)
+  def toZettabitsPerSecond = to(ZettabitsPerSecond)
+  def toYottabitsPerSecond = to(YottabitsPerSecond)
+
+  def toKibibitsPerSecond = to(KibibitsPerSecond)
+  def toMebibitsPerSecond = to(MebibitsPerSecond)
+  def toGibibitsPerSecond = to(GibibitsPerSecond)
+  def toTebibitsPerSecond = to(TebibitsPerSecond)
+  def toPebibitsPerSecond = to(PebibitsPerSecond)
+  def toExbibitsPerSecond = to(ExbibitsPerSecond)
+  def toZebibitsPerSecond = to(ZebibitsPerSecond)
+  def toYobibitsPerSecond = to(YobibitsPerSecond)
 }
 
 
@@ -47,7 +66,11 @@ object DataRate extends Dimension[DataRate] {
   def units = Set(BytesPerSecond, KilobytesPerSecond, KibibytesPerSecond, MegabytesPerSecond, MebibytesPerSecond,
     GigabytesPerSecond, GibibytesPerSecond, TerabytesPerSecond, TebibytesPerSecond,
     PetabytesPerSecond, PebibytesPerSecond, ExabytesPerSecond, ExbibytesPerSecond,
-    ZettabytesPerSecond, ZebibytesPerSecond, YottabytesPerSecond, YobibytesPerSecond)
+    ZettabytesPerSecond, ZebibytesPerSecond, YottabytesPerSecond, YobibytesPerSecond,
+    BitsPerSecond, KilobitsPerSecond, KibibitsPerSecond, MegabitsPerSecond, MebibitsPerSecond,
+    GigabitsPerSecond, GibibitsPerSecond, TerabitsPerSecond, TebibitsPerSecond,
+    PetabitsPerSecond, PebibitsPerSecond, ExabitsPerSecond, ExbibitsPerSecond,
+    ZettabitsPerSecond, ZebibitsPerSecond, YottabitsPerSecond, YobibitsPerSecond)
 }
 
 trait DataRateUnit extends UnitOfMeasure[DataRate] with UnitConverter {
@@ -138,6 +161,92 @@ object YobibytesPerSecond extends DataRateUnit {
   val conversionFactor = Yobibytes.conversionFactor
 }
 
+object BitsPerSecond extends DataRateUnit {
+  val symbol = "bps"
+  val conversionFactor = Bits.conversionFactor
+}
+
+object KilobitsPerSecond extends DataRateUnit {
+  val symbol = "Kbps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Kilobytes.conversionFactor
+}
+
+object KibibitsPerSecond extends DataRateUnit {
+  val symbol = "Kibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Kibibytes.conversionFactor
+}
+
+object MegabitsPerSecond extends DataRateUnit {
+  val symbol = "Mbps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Megabytes.conversionFactor
+}
+
+object MebibitsPerSecond extends DataRateUnit {
+  val symbol = "Mibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Mebibytes.conversionFactor
+}
+
+object GigabitsPerSecond extends DataRateUnit {
+  val symbol = "Gbps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Gigabytes.conversionFactor
+}
+
+object GibibitsPerSecond extends DataRateUnit {
+  val symbol = "Gibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Gibibytes.conversionFactor
+}
+
+object TerabitsPerSecond extends DataRateUnit {
+  val symbol = "Tbps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Terabytes.conversionFactor
+}
+
+object TebibitsPerSecond extends DataRateUnit {
+  val symbol = "Tibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Tebibytes.conversionFactor
+}
+
+object PetabitsPerSecond extends DataRateUnit {
+  val symbol = "Pbps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Petabytes.conversionFactor
+}
+
+object PebibitsPerSecond extends DataRateUnit {
+  val symbol = "Pibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Pebibytes.conversionFactor
+}
+
+object ExabitsPerSecond extends DataRateUnit {
+  val symbol = "Ebps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Exabytes.conversionFactor
+}
+
+object ExbibitsPerSecond extends DataRateUnit {
+  val symbol = "Eibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Exbibytes.conversionFactor
+}
+
+object ZettabitsPerSecond extends DataRateUnit {
+  val symbol = "Zbps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Zettabytes.conversionFactor
+}
+
+object ZebibitsPerSecond extends DataRateUnit {
+  val symbol = "Zibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Zebibytes.conversionFactor
+}
+
+object YottabitsPerSecond extends DataRateUnit {
+  val symbol = "Ybps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Yottabytes.conversionFactor
+}
+
+object YobibitsPerSecond extends DataRateUnit {
+  val symbol = "Yibps"
+  val conversionFactor = BitsPerSecond.conversionFactor * Yobibytes.conversionFactor
+}
+
+
 object DataRateConversions {
   lazy val bytesPerSecond = BytesPerSecond(1)
   lazy val kilobytesPerSecond = KilobytesPerSecond(1)
@@ -157,6 +266,24 @@ object DataRateConversions {
   lazy val yottabytesPerSecond = YottabytesPerSecond(1)
   lazy val yobibytesPerSecond = YobibytesPerSecond(1)
 
+  lazy val bitsPerSecond = BitsPerSecond(1)
+  lazy val kilobitsPerSecond = KilobitsPerSecond(1)
+  lazy val kibibitsPerSecond = KibibitsPerSecond(1)
+  lazy val megabitsPerSecond = MegabitsPerSecond(1)
+  lazy val mebibitsPerSecond = MebibitsPerSecond(1)
+  lazy val gigabitsPerSecond = GigabitsPerSecond(1)
+  lazy val gibibitsPerSecond = GibibitsPerSecond(1)
+  lazy val terabitsPerSecond = TerabitsPerSecond(1)
+  lazy val tebibitsPerSecond = TebibitsPerSecond(1)
+  lazy val petabitsPerSecond = PetabitsPerSecond(1)
+  lazy val pebibitsPerSecond = PebibitsPerSecond(1)
+  lazy val exabitsPerSecond = ExabitsPerSecond(1)
+  lazy val exbibitsPerSecond = ExbibitsPerSecond(1)
+  lazy val zettabitsPerSecond = ZettabitsPerSecond(1)
+  lazy val zebibitsPerSecond = ZebibitsPerSecond(1)
+  lazy val yottabitsPerSecond = YottabitsPerSecond(1)
+  lazy val yobibitsPerSecond = YobibitsPerSecond(1)
+
   implicit class DataRateConversions[A](n: A)(implicit num: Numeric[A]) {
     def bytesPerSecond = BytesPerSecond(n)
     def kilobytesPerSecond = KilobytesPerSecond(n)
@@ -175,6 +302,24 @@ object DataRateConversions {
     def zebibytesPerSecond = ZebibytesPerSecond(n)
     def yottabytesPerSecond = YottabytesPerSecond(n)
     def yobibytesPerSecond = YobibytesPerSecond(n)
+
+    def bitsPerSecond = BitsPerSecond(n)
+    def kilobitsPerSecond = KilobitsPerSecond(n)
+    def kibibitsPerSecond = KibibitsPerSecond(n)
+    def megabitsPerSecond = MegabitsPerSecond(n)
+    def mebibitsPerSecond = MebibitsPerSecond(n)
+    def gigabitsPerSecond = GigabitsPerSecond(n)
+    def gibibitsPerSecond = GibibitsPerSecond(n)
+    def terabitsPerSecond = TerabitsPerSecond(n)
+    def tebibitsPerSecond = TebibitsPerSecond(n)
+    def petabitsPerSecond = PetabitsPerSecond(n)
+    def pebibitsPerSecond = PebibitsPerSecond(n)
+    def exabitsPerSecond = ExabitsPerSecond(n)
+    def exbibitsPerSecond = ExbibitsPerSecond(n)
+    def zettabitsPerSecond = ZettabitsPerSecond(n)
+    def zebibitsPerSecond = ZebibitsPerSecond(n)
+    def yottabitsPerSecond = YottabitsPerSecond(n)
+    def yobibitsPerSecond = YobibitsPerSecond(n)
   }
   
   implicit object DataRateNumeric extends AbstractQuantityNumeric[DataRate](DataRate.primaryUnit)

--- a/shared/src/main/scala/squants/information/Information.scala
+++ b/shared/src/main/scala/squants/information/Information.scala
@@ -44,6 +44,24 @@ final class Information private(val value: Double, val unit: InformationUnit)
   def toZebibytes = to(Zebibytes)
   def toYottabytes = to(Yottabytes)
   def toYobibytes = to(Yobibytes)
+
+  def toBits = to(Bits)
+  def toKilobits = to(Kilobits)
+  def toKibibits = to(Kibibits)
+  def toMegabits = to(Megabits)
+  def toMebibits = to(Mebibits)
+  def toGigabits = to(Gigabits)
+  def toGibibits = to(Gibibits)
+  def toTerabits = to(Terabits)
+  def toTebibits = to(Tebibits)
+  def toPetabits = to(Petabits)
+  def toPebibits = to(Pebibits)
+  def toExabits = to(Exabits)
+  def toExbibits = to(Exbibits)
+  def toZettabits = to(Zettabits)
+  def toZebibits = to(Zebibits)
+  def toYottabits = to(Yottabits)
+  def toYobibits = to(Yobibits)
 }
 
 trait InformationUnit extends UnitOfMeasure[Information] with UnitConverter {
@@ -61,7 +79,10 @@ object Information extends Dimension[Information] with BaseDimension {
   def siUnit = Bytes
   def units = Set(Bytes, Kilobytes, Kibibytes, Megabytes, Mebibytes,
     Gigabytes, Gibibytes, Terabytes, Tebibytes, Petabytes, Pebibytes,
-    Exabytes, Exbibytes, Zettabytes, Zebibytes, Yottabytes, Yobibytes)
+    Exabytes, Exbibytes, Zettabytes, Zebibytes, Yottabytes, Yobibytes,
+    Bits, Kilobits, Kibibits, Megabits, Mebibits, Gigabits, Gibibits,
+    Terabits, Tebibits, Petabits, Pebibits, Exabits, Exbibits,
+    Zettabits, Zebibits, Yottabits, Yobibits)
   def dimensionSymbol = "B"
 }
 
@@ -154,6 +175,91 @@ object Yobibytes extends InformationUnit {
   def symbol = "YiB"
 }
 
+object Bits extends InformationUnit {
+  def conversionFactor = 0.125d
+  val symbol = "bit"
+}
+
+object Kilobits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * MetricSystem.Kilo
+  val symbol = "Kbit"
+}
+
+object Kibibits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * BinarySystem.Kilo
+  val symbol = "Kibit"
+}
+
+object Megabits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * MetricSystem.Mega
+  val symbol = "Mbit"
+}
+
+object Mebibits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * BinarySystem.Mega
+  val symbol = "Mibit"
+}
+
+object Gigabits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * MetricSystem.Giga
+  val symbol = "Gbit"
+}
+
+object Gibibits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * BinarySystem.Giga
+  val symbol = "Gibit"
+}
+
+object Terabits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * MetricSystem.Tera
+  val symbol = "Tbit"
+}
+
+object Tebibits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * BinarySystem.Tera
+  val symbol = "Tibit"
+}
+
+object Petabits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * MetricSystem.Peta
+  val symbol = "Pbit"
+}
+
+object Pebibits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * BinarySystem.Peta
+  val symbol = "Pibit"
+}
+
+object Exabits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * MetricSystem.Exa
+  val symbol = "Ebit"
+}
+
+object Exbibits extends InformationUnit {
+  val conversionFactor = Bits.conversionFactor * BinarySystem.Exa
+  val symbol = "Eibit"
+}
+
+object Zettabits extends InformationUnit {
+  def conversionFactor = Bits.conversionFactor * MetricSystem.Zetta
+  def symbol = "Zbit"
+}
+
+object Zebibits extends InformationUnit {
+  def conversionFactor = Bits.conversionFactor * BinarySystem.Zetta
+  def symbol = "Zibit"
+}
+
+object Yottabits extends InformationUnit {
+  def conversionFactor = Bits.conversionFactor * MetricSystem.Yotta
+  def symbol = "Ybit"
+}
+
+object Yobibits extends InformationUnit {
+  def conversionFactor = Bits.conversionFactor * BinarySystem.Yotta
+  def symbol = "Yibit"
+}
+
 object InformationConversions {
   lazy val byte = Bytes(1)
   lazy val kilobyte = Kilobytes(1)
@@ -172,6 +278,24 @@ object InformationConversions {
   lazy val zebibyte = Zebibytes(1)
   lazy val yottabyte = Yottabytes(1)
   lazy val yobibyte = Yobibytes(1)
+
+  lazy val bit = Bits(1)
+  lazy val kilobit = Kilobits(1)
+  lazy val kibibit = Kibibits(1)
+  lazy val megabit = Megabits(1)
+  lazy val mebibit = Mebibits(1)
+  lazy val gigabit = Gigabits(1)
+  lazy val gibibit = Gibibits(1)
+  lazy val terabit = Terabits(1)
+  lazy val tebibit = Tebibits(1)
+  lazy val petabit = Petabits(1)
+  lazy val pebibit = Pebibits(1)
+  lazy val exabit = Exabits(1)
+  lazy val exbibit = Exbibits(1)
+  lazy val zettabit = Zettabits(1)
+  lazy val zebibit = Zebibits(1)
+  lazy val yottabit = Yottabits(1)
+  lazy val yobibit = Yobibits(1)
 
   implicit class InformationConversions[A](n: A)(implicit num: Numeric[A]) {
     def bytes = Bytes(n)
@@ -208,6 +332,25 @@ object InformationConversions {
     def zebibytes = Zebibytes(n)
     def yib = Yobibytes(n)
     def yobibytes = Yobibytes(n)
+
+    def bits = Bits(n)
+    def kilobits = Kilobits(n)
+    def megabits = Megabits(n)
+    def gigabits = Gigabits(n)
+    def terabits = Terabits(n)
+    def petabits = Petabits(n)
+    def exabits = Exabits(n)
+    def zettabits = Zettabits(n)
+    def yottabits = Yottabits(n)
+
+    def kibibits = Kibibits(n)
+    def mebibits = Mebibits(n)
+    def gibibits = Gibibits(n)
+    def tebibits = Tebibits(n)
+    def pebibits = Pebibits(n)
+    def exbibits = Exbibits(n)
+    def zebibits = Zebibits(n)
+    def yobibits = Yobibits(n)
   }
 
   implicit class InformationStringConversions(s: String) {

--- a/shared/src/test/scala/squants/information/DataRateSpec.scala
+++ b/shared/src/test/scala/squants/information/DataRateSpec.scala
@@ -32,6 +32,26 @@ class DataRateSpec extends FlatSpec with Matchers {
     ExbibytesPerSecond(1).toExbibytesPerSecond should be(1)
     ZebibytesPerSecond(1).toZebibytesPerSecond should be(1)
     YobibytesPerSecond(1).toYobibytesPerSecond should be(1)
+
+    BitsPerSecond(1).toBitsPerSecond should be(1)
+
+    KilobitsPerSecond(1).toKilobitsPerSecond   should be(1)
+    MegabitsPerSecond(1).toMegabitsPerSecond   should be(1)
+    GigabitsPerSecond(1).toGigabitsPerSecond   should be(1)
+    TerabitsPerSecond(1).toTerabitsPerSecond   should be(1)
+    PetabitsPerSecond(1).toPetabitsPerSecond   should be(1)
+    ExabitsPerSecond(1).toExabitsPerSecond     should be(1)
+    ZettabitsPerSecond(1).toZettabitsPerSecond should be(1)
+    YottabitsPerSecond(1).toYottabitsPerSecond should be(1)
+
+    KibibitsPerSecond(1).toKibibitsPerSecond should be(1)
+    MebibitsPerSecond(1).toMebibitsPerSecond should be(1)
+    GibibitsPerSecond(1).toGibibitsPerSecond should be(1)
+    TebibitsPerSecond(1).toTebibitsPerSecond should be(1)
+    PebibitsPerSecond(1).toPebibitsPerSecond should be(1)
+    ExbibitsPerSecond(1).toExbibitsPerSecond should be(1)
+    ZebibitsPerSecond(1).toZebibitsPerSecond should be(1)
+    YobibitsPerSecond(1).toYobibitsPerSecond should be(1)
   }
 
   it should "create values from properly formatted Strings" in {
@@ -55,6 +75,25 @@ class DataRateSpec extends FlatSpec with Matchers {
     DataRate(s"$rate EiB/s").get should be(ExbibytesPerSecond(rate))
     DataRate(s"$rate ZiB/s").get should be(ZebibytesPerSecond(rate))
     DataRate(s"$rate YiB/s").get should be(YobibytesPerSecond(rate))
+
+    DataRate(s"$rate bps").get  should be(BitsPerSecond(rate))
+    DataRate(s"$rate Kbps").get should be(KilobitsPerSecond(rate))
+    DataRate(s"$rate Mbps").get should be(MegabitsPerSecond(rate))
+    DataRate(s"$rate Gbps").get should be(GigabitsPerSecond(rate))
+    DataRate(s"$rate Tbps").get should be(TerabitsPerSecond(rate))
+    DataRate(s"$rate Pbps").get should be(PetabitsPerSecond(rate))
+    DataRate(s"$rate Ebps").get should be(ExabitsPerSecond(rate))
+    DataRate(s"$rate Zbps").get should be(ZettabitsPerSecond(rate))
+    DataRate(s"$rate Ybps").get should be(YottabitsPerSecond(rate))
+
+    DataRate(s"$rate Kibps").get should be(KibibitsPerSecond(rate))
+    DataRate(s"$rate Mibps").get should be(MebibitsPerSecond(rate))
+    DataRate(s"$rate Gibps").get should be(GibibitsPerSecond(rate))
+    DataRate(s"$rate Tibps").get should be(TebibitsPerSecond(rate))
+    DataRate(s"$rate Pibps").get should be(PebibitsPerSecond(rate))
+    DataRate(s"$rate Eibps").get should be(ExbibitsPerSecond(rate))
+    DataRate(s"$rate Zibps").get should be(ZebibitsPerSecond(rate))
+    DataRate(s"$rate Yibps").get should be(YobibitsPerSecond(rate))
 
     DataRate(s"$rate zz").failed.get should be(QuantityParseException("Unable to parse DataRate", s"$rate zz"))
     DataRate("zz B/s").failed.get should be(QuantityParseException("Unable to parse DataRate", "zz B/s"))
@@ -82,6 +121,25 @@ class DataRateSpec extends FlatSpec with Matchers {
     x.toExbibytesPerSecond should be(Bytes(1).toExbibytes / Seconds(1).toSeconds +- tolerance)
     x.toZebibytesPerSecond should be(Bytes(1).toZebibytes / Seconds(1).toSeconds +- tolerance)
     x.toYobibytesPerSecond should be(Bytes(1).toYobibytes / Seconds(1).toSeconds +- tolerance)
+
+    x.toBitsPerSecond      should be(Bytes(1).toBits  / Seconds(1).toSeconds +- tolerance)
+    x.toKilobitsPerSecond  should be(Bytes(1).toKilobits  / Seconds(1).toSeconds +- tolerance)
+    x.toMegabitsPerSecond  should be(Bytes(1).toMegabits  / Seconds(1).toSeconds +- tolerance)
+    x.toGigabitsPerSecond  should be(Bytes(1).toGigabits  / Seconds(1).toSeconds +- tolerance)
+    x.toTerabitsPerSecond  should be(Bytes(1).toTerabits  / Seconds(1).toSeconds +- tolerance)
+    x.toPetabitsPerSecond  should be(Bytes(1).toPetabits  / Seconds(1).toSeconds +- tolerance)
+    x.toExabitsPerSecond   should be(Bytes(1).toExabits   / Seconds(1).toSeconds +- tolerance)
+    x.toZettabitsPerSecond should be(Bytes(1).toZettabits / Seconds(1).toSeconds +- tolerance)
+    x.toYottabitsPerSecond should be(Bytes(1).toYottabits / Seconds(1).toSeconds +- tolerance)
+
+    x.toKibibitsPerSecond should be(Bytes(1).toKibibits / Seconds(1).toSeconds +- tolerance)
+    x.toMebibitsPerSecond should be(Bytes(1).toMebibits / Seconds(1).toSeconds +- tolerance)
+    x.toGibibitsPerSecond should be(Bytes(1).toGibibits / Seconds(1).toSeconds +- tolerance)
+    x.toTebibitsPerSecond should be(Bytes(1).toTebibits / Seconds(1).toSeconds +- tolerance)
+    x.toPebibitsPerSecond should be(Bytes(1).toPebibits / Seconds(1).toSeconds +- tolerance)
+    x.toExbibitsPerSecond should be(Bytes(1).toExbibits / Seconds(1).toSeconds +- tolerance)
+    x.toZebibitsPerSecond should be(Bytes(1).toZebibits / Seconds(1).toSeconds +- tolerance)
+    x.toYobibitsPerSecond should be(Bytes(1).toYobibits / Seconds(1).toSeconds +- tolerance)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
@@ -104,6 +162,25 @@ class DataRateSpec extends FlatSpec with Matchers {
     ExbibytesPerSecond(1).toString(ExbibytesPerSecond) should be("1.0 EiB/s")
     ZebibytesPerSecond(1).toString(ZebibytesPerSecond) should be("1.0 ZiB/s")
     YobibytesPerSecond(1).toString(YobibytesPerSecond) should be("1.0 YiB/s")
+
+    BitsPerSecond(1).toString(BitsPerSecond)           should be("1.0 bps")
+    KilobitsPerSecond(1).toString(KilobitsPerSecond)   should be("1.0 Kbps")
+    MegabitsPerSecond(1).toString(MegabitsPerSecond)   should be("1.0 Mbps")
+    GigabitsPerSecond(1).toString(GigabitsPerSecond)   should be("1.0 Gbps")
+    TerabitsPerSecond(1).toString(TerabitsPerSecond)   should be("1.0 Tbps")
+    PetabitsPerSecond(1).toString(PetabitsPerSecond)   should be("1.0 Pbps")
+    ExabitsPerSecond(1).toString(ExabitsPerSecond)     should be("1.0 Ebps")
+    ZettabitsPerSecond(1).toString(ZettabitsPerSecond) should be("1.0 Zbps")
+    YottabitsPerSecond(1).toString(YottabitsPerSecond) should be("1.0 Ybps")
+
+    KibibitsPerSecond(1).toString(KibibitsPerSecond) should be("1.0 Kibps")
+    MebibitsPerSecond(1).toString(MebibitsPerSecond) should be("1.0 Mibps")
+    GibibitsPerSecond(1).toString(GibibitsPerSecond) should be("1.0 Gibps")
+    TebibitsPerSecond(1).toString(TebibitsPerSecond) should be("1.0 Tibps")
+    PebibitsPerSecond(1).toString(PebibitsPerSecond) should be("1.0 Pibps")
+    ExbibitsPerSecond(1).toString(ExbibitsPerSecond) should be("1.0 Eibps")
+    ZebibitsPerSecond(1).toString(ZebibitsPerSecond) should be("1.0 Zibps")
+    YobibitsPerSecond(1).toString(YobibitsPerSecond) should be("1.0 Yibps")
   }
 
   it should "return Information when multiplied by Time" in {
@@ -138,6 +215,25 @@ class DataRateSpec extends FlatSpec with Matchers {
     exbibytesPerSecond should be(ExbibytesPerSecond(1))
     zebibytesPerSecond should be(ZebibytesPerSecond(1))
     yobibytesPerSecond should be(YobibytesPerSecond(1))
+
+    bitsPerSecond      should be(BitsPerSecond(1))
+    kilobitsPerSecond  should be(KilobitsPerSecond(1))
+    megabitsPerSecond  should be(MegabitsPerSecond(1))
+    gigabitsPerSecond  should be(GigabitsPerSecond(1))
+    terabitsPerSecond  should be(TerabitsPerSecond(1))
+    petabitsPerSecond  should be(PetabitsPerSecond(1))
+    exabitsPerSecond   should be(ExabitsPerSecond(1))
+    zettabitsPerSecond should be(ZettabitsPerSecond(1))
+    yottabitsPerSecond should be(YottabitsPerSecond(1))
+
+    kibibitsPerSecond should be(KibibitsPerSecond(1))
+    mebibitsPerSecond should be(MebibitsPerSecond(1))
+    gibibitsPerSecond should be(GibibitsPerSecond(1))
+    tebibitsPerSecond should be(TebibitsPerSecond(1))
+    pebibitsPerSecond should be(PebibitsPerSecond(1))
+    exbibitsPerSecond should be(ExbibitsPerSecond(1))
+    zebibitsPerSecond should be(ZebibitsPerSecond(1))
+    yobibitsPerSecond should be(YobibitsPerSecond(1))
   }
 
   it should "provide implicit conversion from Double" in {
@@ -163,6 +259,25 @@ class DataRateSpec extends FlatSpec with Matchers {
     dr.exbibytesPerSecond should be(ExbibytesPerSecond(10))
     dr.zebibytesPerSecond should be(ZebibytesPerSecond(10))
     dr.yobibytesPerSecond should be(YobibytesPerSecond(10))
+
+    dr.bitsPerSecond      should be(BitsPerSecond(10))
+    dr.kilobitsPerSecond  should be(KilobitsPerSecond(10))
+    dr.megabitsPerSecond  should be(MegabitsPerSecond(10))
+    dr.gigabitsPerSecond  should be(GigabitsPerSecond(10))
+    dr.terabitsPerSecond  should be(TerabitsPerSecond(10))
+    dr.petabitsPerSecond  should be(PetabitsPerSecond(10))
+    dr.exabitsPerSecond   should be(ExabitsPerSecond(10))
+    dr.zettabitsPerSecond should be(ZettabitsPerSecond(10))
+    dr.yottabitsPerSecond should be(YottabitsPerSecond(10))
+
+    dr.kibibitsPerSecond should be(KibibitsPerSecond(10))
+    dr.mebibitsPerSecond should be(MebibitsPerSecond(10))
+    dr.gibibitsPerSecond should be(GibibitsPerSecond(10))
+    dr.tebibitsPerSecond should be(TebibitsPerSecond(10))
+    dr.pebibitsPerSecond should be(PebibitsPerSecond(10))
+    dr.exbibitsPerSecond should be(ExbibitsPerSecond(10))
+    dr.zebibitsPerSecond should be(ZebibitsPerSecond(10))
+    dr.yobibitsPerSecond should be(YobibitsPerSecond(10))
   }
 
   it should "provide Numeric support" in {

--- a/shared/src/test/scala/squants/information/InformationSpec.scala
+++ b/shared/src/test/scala/squants/information/InformationSpec.scala
@@ -40,6 +40,25 @@ class InformationSpec extends FlatSpec with Matchers {
     Exbibytes(1).toExbibytes should be(1)
     Zebibytes(1).toZebibytes should be(1)
     Yobibytes(1).toYobibytes should be(1)
+
+    Bits(1).toBits should be(1)
+    Kilobits(1).toKilobits should be(1)
+    Megabits(1).toMegabits should be(1)
+    Gigabits(1).toGigabits should be(1)
+    Terabits(1).toTerabits should be(1)
+    Petabits(1).toPetabits should be(1)
+    Exabits(1).toExabits should be(1)
+    Zettabits(1).toZettabits should be(1)
+    Yottabits(1).toYottabits should be(1)
+
+    Kibibits(1).toKibibits should be(1)
+    Mebibits(1).toMebibits should be(1)
+    Gibibits(1).toGibibits should be(1)
+    Tebibits(1).toTebibits should be(1)
+    Pebibits(1).toPebibits should be(1)
+    Exbibits(1).toExbibits should be(1)
+    Zebibits(1).toZebibits should be(1)
+    Yobibits(1).toYobibits should be(1)
   }
 
   it should "create values form properly formatted Strings" in {
@@ -61,6 +80,25 @@ class InformationSpec extends FlatSpec with Matchers {
     Information("100 EiB").get should be(Exbibytes(100))
     Information("100 ZiB").get should be(Zebibytes(100))
     Information("100 YiB").get should be(Yobibytes(100))
+
+    Information("100 bit").get should be(Bits(100))
+    Information("100 Kbit").get should be(Kilobits(100))
+    Information("100 Mbit").get should be(Megabits(100))
+    Information("100 Gbit").get should be(Gigabits(100))
+    Information("100 Tbit").get should be(Terabits(100))
+    Information("100 Pbit").get should be(Petabits(100))
+    Information("100 Ebit").get should be(Exabits(100))
+    Information("100 Zbit").get should be(Zettabits(100))
+    Information("100 Ybit").get should be(Yottabits(100))
+
+    Information("100 Kibit").get should be(Kibibits(100))
+    Information("100 Mibit").get should be(Mebibits(100))
+    Information("100 Gibit").get should be(Gibibits(100))
+    Information("100 Tibit").get should be(Tebibits(100))
+    Information("100 Pibit").get should be(Pebibits(100))
+    Information("100 Eibit").get should be(Exbibits(100))
+    Information("100 Zibit").get should be(Zebibits(100))
+    Information("100 Yibit").get should be(Yobibits(100))
 
     Information("100 zz").failed.get should be(QuantityParseException("Unable to parse Information", "100 zz"))
     Information("ZZ B").failed.get should be(QuantityParseException("Unable to parse Information", "ZZ B"))
@@ -86,6 +124,25 @@ class InformationSpec extends FlatSpec with Matchers {
     x.toExbibytes should be(1 / BinarySystem.Exa)
     x.toZebibytes should be(1 / BinarySystem.Zetta)
     x.toYobibytes should be(1 / BinarySystem.Yotta)
+
+    x.toBits should be(1 / Bits.conversionFactor)
+    x.toKilobits should be(1 / MetricSystem.Kilo / Bits.conversionFactor)
+    x.toMegabits should be(1 / MetricSystem.Mega / Bits.conversionFactor)
+    x.toGigabits should be(1 / MetricSystem.Giga / Bits.conversionFactor)
+    x.toTerabits should be(1 / MetricSystem.Tera / Bits.conversionFactor)
+    x.toPetabits should be(1 / MetricSystem.Peta / Bits.conversionFactor)
+    x.toExabits should be(1 / MetricSystem.Exa / Bits.conversionFactor)
+    x.toZettabits should be(1 / MetricSystem.Zetta / Bits.conversionFactor)
+    x.toYottabits should be(1 / MetricSystem.Yotta / Bits.conversionFactor)
+
+    x.toKibibits should be(1 / BinarySystem.Kilo / Bits.conversionFactor)
+    x.toMebibits should be(1 / BinarySystem.Mega / Bits.conversionFactor)
+    x.toGibibits should be(1 / BinarySystem.Giga / Bits.conversionFactor)
+    x.toTebibits should be(1 / BinarySystem.Tera / Bits.conversionFactor)
+    x.toPebibits should be(1 / BinarySystem.Peta / Bits.conversionFactor)
+    x.toExbibits should be(1 / BinarySystem.Exa / Bits.conversionFactor)
+    x.toZebibits should be(1 / BinarySystem.Zetta / Bits.conversionFactor)
+    x.toYobibits should be(1 / BinarySystem.Yotta / Bits.conversionFactor)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
@@ -107,6 +164,25 @@ class InformationSpec extends FlatSpec with Matchers {
     Exbibytes(1).toString(Exbibytes) should be("1.0 EiB")
     Zebibytes(1).toString(Zebibytes) should be("1.0 ZiB")
     Yobibytes(1).toString(Yobibytes) should be("1.0 YiB")
+
+    Bits(1).toString(Bits) should be("1.0 bit")
+    Kilobits(1).toString(Kilobits) should be("1.0 Kbit")
+    Megabits(1).toString(Megabits) should be("1.0 Mbit")
+    Gigabits(1).toString(Gigabits) should be("1.0 Gbit")
+    Terabits(1).toString(Terabits) should be("1.0 Tbit")
+    Petabits(1).toString(Petabits) should be("1.0 Pbit")
+    Exabits(1).toString(Exabits) should be("1.0 Ebit")
+    Zettabits(1).toString(Zettabits) should be("1.0 Zbit")
+    Yottabits(1).toString(Yottabits) should be("1.0 Ybit")
+
+    Kibibits(1).toString(Kibibits) should be("1.0 Kibit")
+    Mebibits(1).toString(Mebibits) should be("1.0 Mibit")
+    Gibibits(1).toString(Gibibits) should be("1.0 Gibit")
+    Tebibits(1).toString(Tebibits) should be("1.0 Tibit")
+    Pebibits(1).toString(Pebibits) should be("1.0 Pibit")
+    Exbibits(1).toString(Exbibits) should be("1.0 Eibit")
+    Zebibits(1).toString(Zebibits) should be("1.0 Zibit")
+    Yobibits(1).toString(Yobibits) should be("1.0 Yibit")
   }
 
   it should "return Time when divided by DataRate" in {
@@ -136,6 +212,25 @@ class InformationSpec extends FlatSpec with Matchers {
     exbibyte should be(Exbibytes(1))
     zebibyte should be(Zebibytes(1))
     yobibyte should be(Yobibytes(1))
+
+    bit should be(Bits(1))
+    kilobit should be(Kilobits(1))
+    megabit should be(Megabits(1))
+    gigabit should be(Gigabits(1))
+    terabit should be(Terabits(1))
+    petabit should be(Petabits(1))
+    exabit should be(Exabits(1))
+    zettabit should be(Zettabits(1))
+    yottabit should be(Yottabits(1))
+
+    kibibit should be(Kibibits(1))
+    mebibit should be(Mebibits(1))
+    gibibit should be(Gibibits(1))
+    tebibit should be(Tebibits(1))
+    pebibit should be(Pebibits(1))
+    exbibit should be(Exbibits(1))
+    zebibit should be(Zebibits(1))
+    yobibit should be(Yobibits(1))
   }
 
   it should "provide implicit conversion from Double" in {
@@ -177,6 +272,24 @@ class InformationSpec extends FlatSpec with Matchers {
     d.yib should be(Yobibytes(d))
     d.yobibytes should be(Yobibytes(d))
 
+    d.bits should be(Bits(d))
+    d.kilobits should be(Kilobits(d))
+    d.megabits should be(Megabits(d))
+    d.gigabits should be(Gigabits(d))
+    d.terabits should be(Terabits(d))
+    d.petabits should be(Petabits(d))
+    d.exabits should be(Exabits(d))
+    d.zettabits should be(Zettabits(d))
+    d.yottabits should be(Yottabits(d))
+
+    d.kibibits should be(Kibibits(d))
+    d.mebibits should be(Mebibits(d))
+    d.gibibits should be(Gibibits(d))
+    d.tebibits should be(Tebibits(d))
+    d.pebibits should be(Pebibits(d))
+    d.exbibits should be(Exbibits(d))
+    d.zebibits should be(Zebibits(d))
+    d.yobibits should be(Yobibits(d))
   }
 
   it should "provide implicit conversion from String" in {
@@ -200,6 +313,26 @@ class InformationSpec extends FlatSpec with Matchers {
     "100 EiB".toInformation.get should be(Exbibytes(100))
     "100 ZiB".toInformation.get should be(Zebibytes(100))
     "100 YiB".toInformation.get should be(Yobibytes(100))
+
+    "100 bit".toInformation.get should be(Bits(100))
+    "100 Kbit".toInformation.get should be(Kilobits(100))
+    "100 Mbit".toInformation.get should be(Megabits(100))
+    "100 Gbit".toInformation.get should be(Gigabits(100))
+    "100 Tbit".toInformation.get should be(Terabits(100))
+    "100 Pbit".toInformation.get should be(Petabits(100))
+    "100 Ebit".toInformation.get should be(Exabits(100))
+    "100 Zbit".toInformation.get should be(Zettabits(100))
+    "100 Ybit".toInformation.get should be(Yottabits(100))
+
+    "100 Kibit".toInformation.get should be(Kibibits(100))
+    "100 Mibit".toInformation.get should be(Mebibits(100))
+    "100 Gibit".toInformation.get should be(Gibibits(100))
+    "100 Tibit".toInformation.get should be(Tebibits(100))
+    "100 Pibit".toInformation.get should be(Pebibits(100))
+    "100 Eibit".toInformation.get should be(Exbibits(100))
+    "100 Zibit".toInformation.get should be(Zebibits(100))
+    "100 Yibit".toInformation.get should be(Yobibits(100))
+
 
     "100 zz".toInformation.failed.get should be(QuantityParseException("Unable to parse Information", "100 zz"))
     "ZZ B".toInformation.failed.get should be(QuantityParseException("Unable to parse Information", "ZZ B"))


### PR DESCRIPTION
Hi,
I've implemented bit-based units in Information and DataRate classes. Those should help using squants library in telecommunication industry. Issue for that was already open: #304 
Please review and merge if possible.