### PR TITLE
Make all Dimension-objects to be implicit objects

### DIFF
--- a/shared/src/main/scala/squants/Dimensionless.scala
+++ b/shared/src/main/scala/squants/Dimensionless.scala
@@ -45,7 +45,7 @@ final class Dimensionless private (val value: Double, val unit: DimensionlessUni
 /**
  * Factory singleton for [[squants.Dimensionless]]
  */
-object Dimensionless extends Dimension[Dimensionless] {
+implicit object Dimensionless extends Dimension[Dimensionless] {
   def apply[A](n: A, unit: DimensionlessUnit)(implicit num: Numeric[A]) = new Dimensionless(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Dimensionless"

--- a/shared/src/main/scala/squants/electro/AreaElectricChargeDensity.scala
+++ b/shared/src/main/scala/squants/electro/AreaElectricChargeDensity.scala
@@ -21,7 +21,7 @@ final class AreaElectricChargeDensity private (val value: Double, val unit: Area
   def toCoulombsSquareMeters = to(CoulombsPerSquareMeter)
 }
 
-object AreaElectricChargeDensity extends Dimension[AreaElectricChargeDensity] {
+implicit object AreaElectricChargeDensity extends Dimension[AreaElectricChargeDensity] {
   private[electro] def apply[A](n: A, unit: AreaElectricChargeDensityUnit)(implicit num: Numeric[A]) = new AreaElectricChargeDensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "AreaElectricChargeDensity"

--- a/shared/src/main/scala/squants/electro/Capacitance.scala
+++ b/shared/src/main/scala/squants/electro/Capacitance.scala
@@ -32,7 +32,7 @@ final class Capacitance private (val value: Double, val unit: CapacitanceUnit)
   def toKilofarads = to(Kilofarads)
 }
 
-object Capacitance extends Dimension[Capacitance] {
+implicit object Capacitance extends Dimension[Capacitance] {
   private[electro] def apply[A](n: A, unit: CapacitanceUnit)(implicit num: Numeric[A]) = new Capacitance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Capacitance"

--- a/shared/src/main/scala/squants/electro/Conductivity.scala
+++ b/shared/src/main/scala/squants/electro/Conductivity.scala
@@ -28,7 +28,7 @@ final class Conductivity private (val value: Double, val unit: ConductivityUnit)
   def inOhmMeters = OhmMeters(1d / toSiemensPerMeter)
 }
 
-object Conductivity extends Dimension[Conductivity] {
+implicit object Conductivity extends Dimension[Conductivity] {
   private[electro] def apply[A](n: A, unit: ConductivityUnit)(implicit num: Numeric[A]) = new Conductivity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Conductivity"

--- a/shared/src/main/scala/squants/electro/ElectricCharge.scala
+++ b/shared/src/main/scala/squants/electro/ElectricCharge.scala
@@ -46,7 +46,7 @@ final class ElectricCharge private (val value: Double, val unit: ElectricChargeU
   def toMilliampereSeconds = to(MilliampereSeconds)
 }
 
-object ElectricCharge extends Dimension[ElectricCharge] {
+implicit object ElectricCharge extends Dimension[ElectricCharge] {
   private[electro] def apply[A](n: A, unit: ElectricChargeUnit)(implicit num: Numeric[A]) = new ElectricCharge(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricCharge"

--- a/shared/src/main/scala/squants/electro/ElectricChargeDensity.scala
+++ b/shared/src/main/scala/squants/electro/ElectricChargeDensity.scala
@@ -22,7 +22,7 @@ final class ElectricChargeDensity private (val value: Double, val unit: Electric
   def toCoulombsCubicMeters = to(CoulombsPerCubicMeter)
 }
 
-object ElectricChargeDensity extends Dimension[ElectricChargeDensity] {
+implicit object ElectricChargeDensity extends Dimension[ElectricChargeDensity] {
   private[electro] def apply[A](n: A, unit: ElectricChargeDensityUnit)(implicit num: Numeric[A]) = new ElectricChargeDensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricChargeDensity"

--- a/shared/src/main/scala/squants/electro/ElectricChargeMassRatio.scala
+++ b/shared/src/main/scala/squants/electro/ElectricChargeMassRatio.scala
@@ -20,7 +20,7 @@ final class ElectricChargeMassRatio private (val value: Double, val unit: Electr
   def toCoulombsKilograms = to(CoulombsPerKilogram)
 }
 
-object ElectricChargeMassRatio extends Dimension[ElectricChargeMassRatio] {
+implicit object ElectricChargeMassRatio extends Dimension[ElectricChargeMassRatio] {
   private[electro] def apply[A](n: A, unit: ElectricChargeMassRatioUnit)(implicit num: Numeric[A]) = new ElectricChargeMassRatio(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricChargeMassRatio"

--- a/shared/src/main/scala/squants/electro/ElectricCurrent.scala
+++ b/shared/src/main/scala/squants/electro/ElectricCurrent.scala
@@ -40,7 +40,7 @@ final class ElectricCurrent private (val value: Double, val unit: ElectricCurren
   def toMilliamperes = to(Milliamperes)
 }
 
-object ElectricCurrent extends Dimension[ElectricCurrent] with BaseDimension {
+implicit object ElectricCurrent extends Dimension[ElectricCurrent] with BaseDimension {
   private[electro] def apply[A](n: A, unit: ElectricCurrentUnit)(implicit num: Numeric[A]) = new ElectricCurrent(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricCurrent"

--- a/shared/src/main/scala/squants/electro/ElectricCurrentDensity.scala
+++ b/shared/src/main/scala/squants/electro/ElectricCurrentDensity.scala
@@ -21,7 +21,7 @@ final class ElectricCurrentDensity private (val value: Double, val unit: Electri
   def toAmperesPerSquareMeter = to(AmperesPerSquareMeter)
 }
 
-object ElectricCurrentDensity extends Dimension[ElectricCurrentDensity] {
+implicit object ElectricCurrentDensity extends Dimension[ElectricCurrentDensity] {
   private[electro] def apply[A](n: A, unit: ElectricCurrentDensityUnit)(implicit num: Numeric[A]) = new ElectricCurrentDensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricCurrentDensity"

--- a/shared/src/main/scala/squants/electro/ElectricFieldStrength.scala
+++ b/shared/src/main/scala/squants/electro/ElectricFieldStrength.scala
@@ -20,7 +20,7 @@ final class ElectricFieldStrength private (val value: Double, val unit: Electric
   def toVoltsPerMeter = to(VoltsPerMeter)
 }
 
-object ElectricFieldStrength extends Dimension[ElectricFieldStrength] {
+implicit object ElectricFieldStrength extends Dimension[ElectricFieldStrength] {
   private[electro] def apply[A](n: A, unit: ElectricFieldStrengthUnit)(implicit num: Numeric[A]) = new ElectricFieldStrength(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricFieldStrength"

--- a/shared/src/main/scala/squants/electro/ElectricPotential.scala
+++ b/shared/src/main/scala/squants/electro/ElectricPotential.scala
@@ -42,7 +42,7 @@ final class ElectricPotential private (val value: Double, val unit: ElectricPote
   def toMegavolts = to(Megavolts)
 }
 
-object ElectricPotential extends Dimension[ElectricPotential] {
+implicit object ElectricPotential extends Dimension[ElectricPotential] {
   private[electro] def apply[A](n: A, unit: ElectricPotentialUnit)(implicit num: Numeric[A]) = new ElectricPotential(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricPotential"

--- a/shared/src/main/scala/squants/electro/ElectricalConductance.scala
+++ b/shared/src/main/scala/squants/electro/ElectricalConductance.scala
@@ -29,7 +29,7 @@ final class ElectricalConductance private (val value: Double, val unit: Electric
   def inOhms = Ohms(1.0 / value)
 }
 
-object ElectricalConductance extends Dimension[ElectricalConductance] {
+implicit object ElectricalConductance extends Dimension[ElectricalConductance] {
   private[electro] def apply[A](n: A, unit: ElectricalConductanceUnit)(implicit num: Numeric[A]) = new ElectricalConductance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricalConductance"

--- a/shared/src/main/scala/squants/electro/ElectricalResistance.scala
+++ b/shared/src/main/scala/squants/electro/ElectricalResistance.scala
@@ -35,7 +35,7 @@ final class ElectricalResistance private (val value: Double, val unit: Electrica
   def inSiemens = Siemens(1.0 / to(Ohms))
 }
 
-object ElectricalResistance extends Dimension[ElectricalResistance] {
+implicit object ElectricalResistance extends Dimension[ElectricalResistance] {
   private[electro] def apply[A](n: A, unit: ElectricalResistanceUnit)(implicit num: Numeric[A]) = new ElectricalResistance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ElectricalResistance"

--- a/shared/src/main/scala/squants/electro/Inductance.scala
+++ b/shared/src/main/scala/squants/electro/Inductance.scala
@@ -31,7 +31,7 @@ final class Inductance private (val value: Double, val unit: InductanceUnit)
   def toPicohenry = to(Picohenry)
 }
 
-object Inductance extends Dimension[Inductance] {
+implicit object Inductance extends Dimension[Inductance] {
   private[electro] def apply[A](n: A, unit: InductanceUnit)(implicit num: Numeric[A]) = new Inductance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Inductance"

--- a/shared/src/main/scala/squants/electro/LinearElectricChargeDensity.scala
+++ b/shared/src/main/scala/squants/electro/LinearElectricChargeDensity.scala
@@ -21,7 +21,7 @@ final class LinearElectricChargeDensity private (val value: Double, val unit: Li
   def toCoulombsMeters = to(CoulombsPerMeter)
 }
 
-object LinearElectricChargeDensity extends Dimension[LinearElectricChargeDensity] {
+implicit object LinearElectricChargeDensity extends Dimension[LinearElectricChargeDensity] {
   private[electro] def apply[A](n: A, unit: LinearElectricChargeDensityUnit)(implicit num: Numeric[A]) = new LinearElectricChargeDensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "LinearElectricChargeDensity"

--- a/shared/src/main/scala/squants/electro/MagneticFieldStrength.scala
+++ b/shared/src/main/scala/squants/electro/MagneticFieldStrength.scala
@@ -20,7 +20,7 @@ final class MagneticFieldStrength private (val value: Double, val unit: Magnetic
   def toAmperesPerMeter = to(AmperesPerMeter)
 }
 
-object MagneticFieldStrength extends Dimension[MagneticFieldStrength] {
+implicit object MagneticFieldStrength extends Dimension[MagneticFieldStrength] {
   private[electro] def apply[A](n: A, unit: MagneticFieldStrengthUnit)(implicit num: Numeric[A]) = new MagneticFieldStrength(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "MagneticFieldStrength"

--- a/shared/src/main/scala/squants/electro/MagneticFlux.scala
+++ b/shared/src/main/scala/squants/electro/MagneticFlux.scala
@@ -35,7 +35,7 @@ final class MagneticFlux private (val value: Double, val unit: MagneticFluxUnit)
   def toWebers = to(Webers)
 }
 
-object MagneticFlux extends Dimension[MagneticFlux] {
+implicit object MagneticFlux extends Dimension[MagneticFlux] {
   private[electro] def apply[A](n: A, unit: MagneticFluxUnit)(implicit num: Numeric[A]) = new MagneticFlux(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "MagneticFlux"

--- a/shared/src/main/scala/squants/electro/MagneticFluxDensity.scala
+++ b/shared/src/main/scala/squants/electro/MagneticFluxDensity.scala
@@ -27,7 +27,7 @@ final class MagneticFluxDensity private (val value: Double, val unit: MagneticFl
   def toGuass = to(Gauss)
 }
 
-object MagneticFluxDensity extends Dimension[MagneticFluxDensity] {
+implicit object MagneticFluxDensity extends Dimension[MagneticFluxDensity] {
   private[electro] def apply[A](n: A, unit: MagneticFluxDensityUnit)(implicit num: Numeric[A]) = new MagneticFluxDensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "MagneticFluxDensity"

--- a/shared/src/main/scala/squants/electro/Permeability.scala
+++ b/shared/src/main/scala/squants/electro/Permeability.scala
@@ -32,7 +32,7 @@ final class Permeability private (val value: Double, val unit: PermeabilityUnit)
   def toNewtonsPerAmpereSquared = to(NewtonsPerAmperesSquared)
 }
 
-object Permeability extends Dimension[Permeability] {
+implicit object Permeability extends Dimension[Permeability] {
   private[electro] def apply[A](n: A, unit: PermeabilityUnit)(implicit num: Numeric[A]) = new Permeability(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   val name = "Permeability"

--- a/shared/src/main/scala/squants/electro/Permittivity.scala
+++ b/shared/src/main/scala/squants/electro/Permittivity.scala
@@ -20,7 +20,7 @@ final class Permittivity private (val value: Double, val unit: PermittivityUnit)
   def toFaradsMeters = to(FaradsPerMeter)
 }
 
-object Permittivity extends Dimension[Permittivity] {
+implicit object Permittivity extends Dimension[Permittivity] {
   private[electro] def apply[A](n: A, unit: PermittivityUnit)(implicit num: Numeric[A]) = new Permittivity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Permittivity"

--- a/shared/src/main/scala/squants/electro/Resistivity.scala
+++ b/shared/src/main/scala/squants/electro/Resistivity.scala
@@ -28,7 +28,7 @@ final class Resistivity private (val value: Double, val unit: ResistivityUnit)
   def inSiemensPerMeter = SiemensPerMeter(1d / toOhmMeters)
 }
 
-object Resistivity extends Dimension[Resistivity] {
+implicit object Resistivity extends Dimension[Resistivity] {
   private[electro] def apply[A](n: A, unit: ResistivityUnit)(implicit num: Numeric[A]) = new Resistivity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Resistivity"

--- a/shared/src/main/scala/squants/energy/Energy.scala
+++ b/shared/src/main/scala/squants/energy/Energy.scala
@@ -92,7 +92,7 @@ final class Energy private (val value: Double, val unit: EnergyUnit)
 /**
  * Companion object for [[squants.energy.Energy]]
  */
-object Energy extends Dimension[Energy] {
+implicit object Energy extends Dimension[Energy] {
   private[energy] def apply[A](n: A, unit: EnergyUnit)(implicit num: Numeric[A]) = new Energy(num.toDouble(n), unit)
   def apply(load: Power, time: Time): Energy = load * time
   def apply(value: Any) = parse(value)

--- a/shared/src/main/scala/squants/energy/EnergyDensity.scala
+++ b/shared/src/main/scala/squants/energy/EnergyDensity.scala
@@ -28,7 +28,7 @@ final class EnergyDensity private (val value: Double, val unit: EnergyDensityUni
   def toJoulesPerCubicMeter = to(JoulesPerCubicMeter)
 }
 
-object EnergyDensity extends Dimension[EnergyDensity] {
+implicit object EnergyDensity extends Dimension[EnergyDensity] {
   private[energy] def apply[A](n: A, unit: EnergyDensityUnit)(implicit num: Numeric[A]) = new EnergyDensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "EnergyDensity"

--- a/shared/src/main/scala/squants/energy/MolarEnergy.scala
+++ b/shared/src/main/scala/squants/energy/MolarEnergy.scala
@@ -20,7 +20,7 @@ final class MolarEnergy private (val value: Double, val unit: MolarEnergyUnit)
   def toJoulesPerMole = to(JoulesPerMole)
 }
 
-object MolarEnergy extends Dimension[MolarEnergy] {
+implicit object MolarEnergy extends Dimension[MolarEnergy] {
   private[energy] def apply[A](n: A, unit: MolarEnergyUnit)(implicit num: Numeric[A]) = new MolarEnergy(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "MolarEnergy"

--- a/shared/src/main/scala/squants/energy/Power.scala
+++ b/shared/src/main/scala/squants/energy/Power.scala
@@ -58,7 +58,7 @@ final class Power private (val value: Double, val unit: PowerUnit)
 /**
  * Companion object for [[squants.energy.Power]]
  */
-object Power extends Dimension[Power] {
+implicit object Power extends Dimension[Power] {
   private[energy] def apply[A](n: A, unit: PowerUnit)(implicit num: Numeric[A]) = new Power(num.toDouble(n), unit)
   def apply(energy: Energy, time: Time): Power = apply(energy.toWattHours / time.toHours, Watts)
   def apply(value: Any) = parse(value)

--- a/shared/src/main/scala/squants/energy/PowerDensity.scala
+++ b/shared/src/main/scala/squants/energy/PowerDensity.scala
@@ -28,7 +28,7 @@ final class PowerDensity private (val value: Double, val unit: PowerDensityUnit)
   def toWattsPerCubicMeter = to(WattsPerCubicMeter)
 }
 
-object PowerDensity extends Dimension[PowerDensity] {
+implicit object PowerDensity extends Dimension[PowerDensity] {
   private[energy] def apply[A](n: A, unit: PowerDensityUnit)(implicit num: Numeric[A]) = new PowerDensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "PowerDensity"

--- a/shared/src/main/scala/squants/energy/PowerRamp.scala
+++ b/shared/src/main/scala/squants/energy/PowerRamp.scala
@@ -39,7 +39,7 @@ final class PowerRamp private (val value: Double, val unit: PowerRampUnit)
   def toGigawattsPerHour = to(GigawattsPerHour)
 }
 
-object PowerRamp extends Dimension[PowerRamp] {
+implicit object PowerRamp extends Dimension[PowerRamp] {
   private[energy] def apply[A](n: A, unit: PowerRampUnit)(implicit num: Numeric[A]) = new PowerRamp(num.toDouble(n), unit)
   def apply(change: Power, time: Time): PowerRamp = apply(change.toWatts / time.toHours, WattsPerHour)
   def apply(value: Any) = parse(value)

--- a/shared/src/main/scala/squants/energy/SpecificEnergy.scala
+++ b/shared/src/main/scala/squants/energy/SpecificEnergy.scala
@@ -26,7 +26,7 @@ final class SpecificEnergy private (val value: Double, val unit: SpecificEnergyU
   def toGrays = to(Grays)
 }
 
-object SpecificEnergy extends Dimension[SpecificEnergy] {
+implicit object SpecificEnergy extends Dimension[SpecificEnergy] {
   private[energy] def apply[A](n: A, unit: SpecificEnergyUnit)(implicit num: Numeric[A]) = new SpecificEnergy(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "SpecificEnergy"

--- a/shared/src/main/scala/squants/information/DataRate.scala
+++ b/shared/src/main/scala/squants/information/DataRate.scala
@@ -54,7 +54,7 @@ final class DataRate private(val value: Double, val unit: DataRateUnit)
 }
 
 
-object DataRate extends Dimension[DataRate] {
+implicit object DataRate extends Dimension[DataRate] {
   private[information] def apply[A](n: A, unit: DataRateUnit)(implicit num: Numeric[A]) =
     new DataRate(num.toDouble(n), unit)
 

--- a/shared/src/main/scala/squants/information/Information.scala
+++ b/shared/src/main/scala/squants/information/Information.scala
@@ -71,7 +71,7 @@ trait InformationUnit extends UnitOfMeasure[Information] with UnitConverter {
 /**
  * Factory singleton for information
  */
-object Information extends Dimension[Information] with BaseDimension {
+implicit object Information extends Dimension[Information] with BaseDimension {
   private[information] def apply[A](n: A, unit: InformationUnit)(implicit num: Numeric[A]) = new Information(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Information"

--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -382,7 +382,7 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
 /**
  * Factory singleton for Money
  */
-object Money extends Dimension[Money] {
+implicit object Money extends Dimension[Money] {
   def apply(value: Double)(implicit fxContext: MoneyContext) = new Money(BigDecimal(value))(fxContext.defaultCurrency)
   def apply(value: BigDecimal)(implicit fxContext: MoneyContext) = new Money(value)(fxContext.defaultCurrency)
 

--- a/shared/src/main/scala/squants/mass/AreaDensity.scala
+++ b/shared/src/main/scala/squants/mass/AreaDensity.scala
@@ -33,7 +33,7 @@ final class AreaDensity private (val value: Double, val unit: AreaDensityUnit)
 /**
  * Factory singleton for [[squants.mass.AreaDensity]] values
  */
-object AreaDensity extends Dimension[AreaDensity] {
+implicit object AreaDensity extends Dimension[AreaDensity] {
   private[mass] def apply[A](n: A, unit: AreaDensityUnit)(implicit num: Numeric[A]) = new AreaDensity(num.toDouble(n), unit)
   def apply(mass: Mass, area: Area): AreaDensity = KilogramsPerSquareMeter(mass.toKilograms / area.toSquareMeters)
   def apply(value: Any) = parse(value)

--- a/shared/src/main/scala/squants/mass/ChemicalAmount.scala
+++ b/shared/src/main/scala/squants/mass/ChemicalAmount.scala
@@ -27,7 +27,7 @@ final class ChemicalAmount private (val value: Double, val unit: ChemicalAmountU
   def toPoundMoles = to(PoundMoles)
 }
 
-object ChemicalAmount extends Dimension[ChemicalAmount] with BaseDimension {
+implicit object ChemicalAmount extends Dimension[ChemicalAmount] with BaseDimension {
   private[mass] def apply[A](n: A, unit: ChemicalAmountUnit)(implicit num: Numeric[A]) = new ChemicalAmount(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   val name = "ChemicalAmount"

--- a/shared/src/main/scala/squants/mass/Density.scala
+++ b/shared/src/main/scala/squants/mass/Density.scala
@@ -26,7 +26,7 @@ final class Density private (val value: Double, val unit: DensityUnit)
   def toKilogramsPerCubicMeter = to(KilogramsPerCubicMeter)
 }
 
-object Density extends Dimension[Density] {
+implicit object Density extends Dimension[Density] {
   private[mass] def apply[A](n: A, unit: DensityUnit)(implicit num: Numeric[A]) = new Density(num.toDouble(n), unit)
   def apply(m: Mass, v: Volume): Density = KilogramsPerCubicMeter(m.toKilograms / v.toCubicMeters)
   def apply(value: Any) = parse(value)

--- a/shared/src/main/scala/squants/mass/Mass.scala
+++ b/shared/src/main/scala/squants/mass/Mass.scala
@@ -79,7 +79,7 @@ final class Mass private (val value: Double, val unit: MassUnit)
 /**
  * Factory singleton for [[squants.mass.Mass]] values
  */
-object Mass extends Dimension[Mass] with BaseDimension {
+implicit object Mass extends Dimension[Mass] with BaseDimension {
   private[mass] def apply[A](n: A, unit: MassUnit)(implicit num: Numeric[A]) = new Mass(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Mass"

--- a/shared/src/main/scala/squants/mass/MomentOfIntertia.scala
+++ b/shared/src/main/scala/squants/mass/MomentOfIntertia.scala
@@ -36,7 +36,7 @@ final class MomentOfInertia private (val value: Double, val unit: MomentOfInerti
   }
 }
 
-object MomentOfInertia extends Dimension[MomentOfInertia] {
+implicit object MomentOfInertia extends Dimension[MomentOfInertia] {
   private[mass] def apply[A](n: A, unit: MomentOfInertiaUnit)(implicit num: Numeric[A]) = new MomentOfInertia(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "MomentOfInertia"

--- a/shared/src/main/scala/squants/motion/Acceleration.scala
+++ b/shared/src/main/scala/squants/motion/Acceleration.scala
@@ -58,7 +58,7 @@ final class Acceleration private (val value: Double, val unit: AccelerationUnit)
   }
 }
 
-object Acceleration extends Dimension[Acceleration] {
+implicit object Acceleration extends Dimension[Acceleration] {
   private[motion] def apply[A](n: A, unit: AccelerationUnit)(implicit num: Numeric[A]) = new Acceleration(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Acceleration"

--- a/shared/src/main/scala/squants/motion/AngularAcceleration.scala
+++ b/shared/src/main/scala/squants/motion/AngularAcceleration.scala
@@ -42,7 +42,7 @@ final class AngularAcceleration private (val value: Double, val unit: AngularAcc
   override protected[squants] def time: Time = Seconds(1)
 }
 
-object AngularAcceleration extends Dimension[AngularAcceleration] {
+implicit object AngularAcceleration extends Dimension[AngularAcceleration] {
   private[motion] def apply[A](n: A, unit: AngularAccelerationUnit)(implicit num: Numeric[A]) = new AngularAcceleration(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "AngularAcceleration"

--- a/shared/src/main/scala/squants/motion/AngularVelocity.scala
+++ b/shared/src/main/scala/squants/motion/AngularVelocity.scala
@@ -45,7 +45,7 @@ final class AngularVelocity private (val value: Double, val unit: AngularVelocit
   protected[squants] def time: Time = Seconds(1)
 }
 
-object AngularVelocity extends Dimension[AngularVelocity] {
+implicit object AngularVelocity extends Dimension[AngularVelocity] {
   private[motion] def apply[A](n: A, unit: AngularVelocityUnit)(implicit num: Numeric[A]) = new AngularVelocity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "AngularVelocity"

--- a/shared/src/main/scala/squants/motion/Force.scala
+++ b/shared/src/main/scala/squants/motion/Force.scala
@@ -43,7 +43,7 @@ final class Force private (val value: Double, val unit: ForceUnit)
   def toPoundForce = to(PoundForce)
 }
 
-object Force extends Dimension[Force] {
+implicit object Force extends Dimension[Force] {
   private[motion] def apply[A](n: A, unit: ForceUnit)(implicit num: Numeric[A]) = new Force(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Force"

--- a/shared/src/main/scala/squants/motion/Jerk.scala
+++ b/shared/src/main/scala/squants/motion/Jerk.scala
@@ -36,7 +36,7 @@ final class Jerk private (val value: Double, val unit: JerkUnit)
   def toFeetPerSecondCubed = to(FeetPerSecondCubed)
 }
 
-object Jerk extends Dimension[Jerk] {
+implicit object Jerk extends Dimension[Jerk] {
   private[motion] def apply[A](n: A, unit: JerkUnit)(implicit num: Numeric[A]) = new Jerk(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Jerk"

--- a/shared/src/main/scala/squants/motion/MassFlow.scala
+++ b/shared/src/main/scala/squants/motion/MassFlow.scala
@@ -34,7 +34,7 @@ final class MassFlow private (val value: Double, val unit: MassFlowUnit)
   def toMegapoundsPerHour = to(MegapoundsPerHour)
 }
 
-object MassFlow extends Dimension[MassFlow] {
+implicit object MassFlow extends Dimension[MassFlow] {
   private[motion] def apply[A](n: A, unit: MassFlowUnit)(implicit num: Numeric[A]) = new MassFlow(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "MassFlow"

--- a/shared/src/main/scala/squants/motion/Momentum.scala
+++ b/shared/src/main/scala/squants/motion/Momentum.scala
@@ -37,7 +37,7 @@ final class Momentum private (val value: Double, val unit: MomentumUnit)
   def toNewtonSeconds = to(NewtonSeconds)
 }
 
-object Momentum extends Dimension[Momentum] {
+implicit object Momentum extends Dimension[Momentum] {
   private[motion] def apply[A](n: A, unit: MomentumUnit)(implicit num: Numeric[A]) = new Momentum(num.toDouble(n), unit)
   def apply(m: Mass, v: Velocity): Momentum = NewtonSeconds(m.toKilograms * v.toMetersPerSecond)
   def apply(value: Any) = parse(value)

--- a/shared/src/main/scala/squants/motion/Pressure.scala
+++ b/shared/src/main/scala/squants/motion/Pressure.scala
@@ -39,7 +39,7 @@ final class Pressure private (val value: Double, val unit: PressureUnit)
   def toTorr: Double                 = to(Torrs)
 }
 
-object Pressure extends Dimension[Pressure] {
+implicit object Pressure extends Dimension[Pressure] {
   private[motion] def apply[A](n: A, unit: PressureUnit)(implicit num: Numeric[A]) = new Pressure(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Pressure"

--- a/shared/src/main/scala/squants/motion/PressureChange.scala
+++ b/shared/src/main/scala/squants/motion/PressureChange.scala
@@ -32,7 +32,7 @@ final class PressureChange private (val value: Double, val unit: PressureChangeU
   def toStandardAtmospheresPerSecond = to(StandardAtmospheresPerSecond)
 }
 
-object PressureChange extends Dimension[PressureChange] {
+implicit object PressureChange extends Dimension[PressureChange] {
   private[motion] def apply[A](n: A, unit: PressureChangeUnit)(implicit num: Numeric[A]) = new PressureChange(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "PressureChange"

--- a/shared/src/main/scala/squants/motion/Torque.scala
+++ b/shared/src/main/scala/squants/motion/Torque.scala
@@ -24,7 +24,7 @@ final class Torque private (val value: Double, val unit: TorqueUnit)
   }
 }
 
-object Torque extends Dimension[Torque] {
+implicit object Torque extends Dimension[Torque] {
   private[motion] def apply[A](n: A, unit: TorqueUnit)(implicit num: Numeric[A]) = new Torque(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Torque"

--- a/shared/src/main/scala/squants/motion/Velocity.scala
+++ b/shared/src/main/scala/squants/motion/Velocity.scala
@@ -47,7 +47,7 @@ final class Velocity private (val value: Double, val unit: VelocityUnit)
   def toKnots = to(Knots)
 }
 
-object Velocity extends Dimension[Velocity] {
+implicit object Velocity extends Dimension[Velocity] {
   private[motion] def apply[A](n: A, unit: VelocityUnit)(implicit num: Numeric[A]) = new Velocity(num.toDouble(n), unit)
   def apply(l: Length, t: Time) = MetersPerSecond(l.toMeters / t.toSeconds)
   def apply(value: Any) = parse(value)

--- a/shared/src/main/scala/squants/motion/VolumeFlow.scala
+++ b/shared/src/main/scala/squants/motion/VolumeFlow.scala
@@ -35,7 +35,7 @@ final class VolumeFlow private (val value: Double, val unit: VolumeFlowRateUnit)
   def toGallonsPerSecond = to(GallonsPerSecond)
 }
 
-object VolumeFlow extends Dimension[VolumeFlow] {
+implicit object VolumeFlow extends Dimension[VolumeFlow] {
   private[motion] def apply[A](n: A, unit: VolumeFlowRateUnit)(implicit num: Numeric[A]) = new VolumeFlow(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "VolumeFlow"

--- a/shared/src/main/scala/squants/motion/Yank.scala
+++ b/shared/src/main/scala/squants/motion/Yank.scala
@@ -32,7 +32,7 @@ final class Yank private (val value: Double, val unit: YankUnit)
   def toNewtonsPerSecond = to(NewtonsPerSecond)
 }
 
-object Yank extends Dimension[Yank] {
+implicit object Yank extends Dimension[Yank] {
   private[motion] def apply[A](n: A, unit: YankUnit)(implicit num: Numeric[A]) = new Yank(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Yank"

--- a/shared/src/main/scala/squants/photo/Illuminance.scala
+++ b/shared/src/main/scala/squants/photo/Illuminance.scala
@@ -30,7 +30,7 @@ final class Illuminance private (val value: Double, val unit: IlluminanceUnit)
   def toLux = to(Lux)
 }
 
-object Illuminance extends Dimension[Illuminance] {
+implicit object Illuminance extends Dimension[Illuminance] {
   private[photo] def apply[A](n: A, unit: IlluminanceUnit)(implicit num: Numeric[A]) = new Illuminance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Illuminance"

--- a/shared/src/main/scala/squants/photo/Luminance.scala
+++ b/shared/src/main/scala/squants/photo/Luminance.scala
@@ -25,7 +25,7 @@ final class Luminance private (val value: Double, val unit: LuminanceUnit)
   def toCandelasPerSquareMeters = to(CandelasPerSquareMeter)
 }
 
-object Luminance extends Dimension[Luminance] {
+implicit object Luminance extends Dimension[Luminance] {
   private[photo] def apply[A](n: A, unit: LuminanceUnit)(implicit num: Numeric[A]) = new Luminance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
 

--- a/shared/src/main/scala/squants/photo/LuminousEnergy.scala
+++ b/shared/src/main/scala/squants/photo/LuminousEnergy.scala
@@ -28,7 +28,7 @@ final class LuminousEnergy private (val value: Double, val unit: LuminousEnergyU
   def toLumenSeconds = to(LumenSeconds)
 }
 
-object LuminousEnergy extends Dimension[LuminousEnergy] {
+implicit object LuminousEnergy extends Dimension[LuminousEnergy] {
   private[photo] def apply[A](n: A, unit: LuminousEnergyUnit)(implicit num: Numeric[A]) = new LuminousEnergy(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "LuminousEnergy"

--- a/shared/src/main/scala/squants/photo/LuminousExposure.scala
+++ b/shared/src/main/scala/squants/photo/LuminousExposure.scala
@@ -29,7 +29,7 @@ final class LuminousExposure private (val value: Double, val unit: LuminousExpos
   def toLuxSeconds = to(LuxSeconds)
 }
 
-object LuminousExposure extends Dimension[LuminousExposure] {
+implicit object LuminousExposure extends Dimension[LuminousExposure] {
   private[photo] def apply[A](n: A, unit: LuminousExposureUnit)(implicit num: Numeric[A]) = new LuminousExposure(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "LuminousExposure"

--- a/shared/src/main/scala/squants/photo/LuminousFlux.scala
+++ b/shared/src/main/scala/squants/photo/LuminousFlux.scala
@@ -35,7 +35,7 @@ final class LuminousFlux private (val value: Double, val unit: LuminousFluxUnit)
   def toLumens = to(Lumens)
 }
 
-object LuminousFlux extends Dimension[LuminousFlux] {
+implicit object LuminousFlux extends Dimension[LuminousFlux] {
   private[photo] def apply[A](n: A, unit: LuminousFluxUnit)(implicit num: Numeric[A]) = new LuminousFlux(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "LuminousFlux"

--- a/shared/src/main/scala/squants/photo/LuminousIntensity.scala
+++ b/shared/src/main/scala/squants/photo/LuminousIntensity.scala
@@ -28,7 +28,7 @@ final class LuminousIntensity private (val value: Double, val unit: LuminousInte
   def toCandelas = to(Candelas)
 }
 
-object LuminousIntensity extends Dimension[LuminousIntensity] with BaseDimension {
+implicit object LuminousIntensity extends Dimension[LuminousIntensity] with BaseDimension {
   private[photo] def apply[A](n: A, unit: LuminousIntensityUnit)(implicit num: Numeric[A]) = new LuminousIntensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "LuminousIntensity"

--- a/shared/src/main/scala/squants/radio/Irradiance.scala
+++ b/shared/src/main/scala/squants/radio/Irradiance.scala
@@ -29,7 +29,7 @@ final class Irradiance private (val value: Double, val unit: IrradianceUnit)
   def toErgsPerSecondPerSquareCentimeter = to(ErgsPerSecondPerSquareCentimeter)
 }
 
-object Irradiance extends Dimension[Irradiance] {
+implicit object Irradiance extends Dimension[Irradiance] {
   private[radio] def apply[A](n: A, unit: IrradianceUnit)(implicit num: Numeric[A]) = new Irradiance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Irradiance"

--- a/shared/src/main/scala/squants/radio/Radiance.scala
+++ b/shared/src/main/scala/squants/radio/Radiance.scala
@@ -29,7 +29,7 @@ final class Radiance private (val value: Double, val unit: RadianceUnit)
   def toWattsPerSteradianPerSquareMeter = to(WattsPerSteradianPerSquareMeter)
 }
 
-object Radiance extends Dimension[Radiance] {
+implicit object Radiance extends Dimension[Radiance] {
   private[radio] def apply[A](n: A, unit: RadianceUnit)(implicit num: Numeric[A]) = new Radiance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Radiance"

--- a/shared/src/main/scala/squants/radio/RadiantIntensity.scala
+++ b/shared/src/main/scala/squants/radio/RadiantIntensity.scala
@@ -33,7 +33,7 @@ final class RadiantIntensity private (val value: Double, val unit: RadiantIntens
   def toWattsPerSteradian = to(WattsPerSteradian)
 }
 
-object RadiantIntensity extends Dimension[RadiantIntensity] {
+implicit object RadiantIntensity extends Dimension[RadiantIntensity] {
   private[radio] def apply[A](n: A, unit: RadiantIntensityUnit)(implicit num: Numeric[A]) = new RadiantIntensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "RadiantIntensity"

--- a/shared/src/main/scala/squants/radio/SpectralIntensity.scala
+++ b/shared/src/main/scala/squants/radio/SpectralIntensity.scala
@@ -29,7 +29,7 @@ final class SpectralIntensity private (val value: Double, val unit: SpectralInte
   def toWattsPerSteradianPerMeter = to(WattsPerSteradianPerMeter)
 }
 
-object SpectralIntensity extends Dimension[SpectralIntensity] {
+implicit object SpectralIntensity extends Dimension[SpectralIntensity] {
   private[radio] def apply[A](n: A, unit: SpectralIntensityUnit)(implicit num: Numeric[A]) = new SpectralIntensity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "SpectralIntensity"

--- a/shared/src/main/scala/squants/radio/SpectralIrradiance.scala
+++ b/shared/src/main/scala/squants/radio/SpectralIrradiance.scala
@@ -29,7 +29,7 @@ final class SpectralIrradiance private (val value: Double, val unit: SpectralIrr
   def toErgsPerSecondPerSquareCentimeterPerAngstrom = to(ErgsPerSecondPerSquareCentimeterPerAngstrom)
 }
 
-object SpectralIrradiance extends Dimension[SpectralIrradiance] {
+implicit object SpectralIrradiance extends Dimension[SpectralIrradiance] {
   private[radio] def apply[A](n: A, unit: SpectralIrradianceUnit)(implicit num: Numeric[A]) = new SpectralIrradiance(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "SpectralIrradiance"

--- a/shared/src/main/scala/squants/radio/SpectralPower.scala
+++ b/shared/src/main/scala/squants/radio/SpectralPower.scala
@@ -29,7 +29,7 @@ final class SpectralPower private (val value: Double, val unit: SpectralPowerUni
   def toWattsPerMeter = value
 }
 
-object SpectralPower extends Dimension[SpectralPower] {
+implicit object SpectralPower extends Dimension[SpectralPower] {
   private[radio] def apply[A](n: A, unit: SpectralPowerUnit)(implicit num: Numeric[A]) = new SpectralPower(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "SpectralPower"

--- a/shared/src/main/scala/squants/space/Angle.scala
+++ b/shared/src/main/scala/squants/space/Angle.scala
@@ -51,7 +51,7 @@ final class Angle private (val value: Double, val unit: AngleUnit)
   override protected def time: Time = Seconds(1)
 }
 
-object Angle extends Dimension[Angle] {
+implicit object Angle extends Dimension[Angle] {
   private[space] def apply[A](n: A, unit: AngleUnit)(implicit num: Numeric[A]) = new Angle(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Angle"

--- a/shared/src/main/scala/squants/space/Area.scala
+++ b/shared/src/main/scala/squants/space/Area.scala
@@ -65,7 +65,7 @@ final class Area private (val value: Double, val unit: AreaUnit)
   def toBarnes = to(Barnes)
 }
 
-object Area extends Dimension[Area] {
+implicit object Area extends Dimension[Area] {
   private[space] def apply[A](n: A, unit: AreaUnit)(implicit num: Numeric[A]) = new Area(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Area"

--- a/shared/src/main/scala/squants/space/Length.scala
+++ b/shared/src/main/scala/squants/space/Length.scala
@@ -100,7 +100,7 @@ final class Length private (val value: Double, val unit: LengthUnit)
 /**
  * Factory singleton for length
  */
-object Length extends Dimension[Length] with BaseDimension {
+implicit object Length extends Dimension[Length] with BaseDimension {
   private[space] def apply[A](n: A, unit: LengthUnit)(implicit num: Numeric[A]) = new Length(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Length"

--- a/shared/src/main/scala/squants/space/SolidAngle.scala
+++ b/shared/src/main/scala/squants/space/SolidAngle.scala
@@ -31,7 +31,7 @@ final class SolidAngle private (val value: Double, val unit: SolidAngleUnit)
   def toSteradians = value
 }
 
-object SolidAngle extends Dimension[SolidAngle] {
+implicit object SolidAngle extends Dimension[SolidAngle] {
   private[space] def apply[A](n: A, unit: SolidAngleUnit)(implicit num: Numeric[A]) = new SolidAngle(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "SolidAngle"

--- a/shared/src/main/scala/squants/space/Volume.scala
+++ b/shared/src/main/scala/squants/space/Volume.scala
@@ -90,7 +90,7 @@ final class Volume private (val value: Double, val unit: VolumeUnit)
   def toAcreFeet = to(AcreFeet)
 }
 
-object Volume extends Dimension[Volume] {
+implicit object Volume extends Dimension[Volume] {
   private[space] def apply[A](n: A, unit: VolumeUnit)(implicit num: Numeric[A]) = new Volume(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Volume"

--- a/shared/src/main/scala/squants/thermal/Temperature.scala
+++ b/shared/src/main/scala/squants/thermal/Temperature.scala
@@ -137,7 +137,7 @@ final class Temperature private (val value: Double, val unit: TemperatureScale)
 /**
  * Temperature companion object
  */
-object Temperature extends Dimension[Temperature] with BaseDimension {
+implicit object Temperature extends Dimension[Temperature] with BaseDimension {
   def apply[A](n: A, scale: TemperatureScale)(implicit num: Numeric[A]) = new Temperature(num.toDouble(n), scale)
 
   def apply(s: String): Try[Temperature] = {

--- a/shared/src/main/scala/squants/thermal/ThermalCapacity.scala
+++ b/shared/src/main/scala/squants/thermal/ThermalCapacity.scala
@@ -31,7 +31,7 @@ final class ThermalCapacity private (val value: Double, val unit: ThermalCapacit
   def toJoulesPerKelvin = to(JoulesPerKelvin)
 }
 
-object ThermalCapacity extends Dimension[ThermalCapacity] {
+implicit object ThermalCapacity extends Dimension[ThermalCapacity] {
   private[thermal] def apply[A](n: A, unit: ThermalCapacityUnit)(implicit num: Numeric[A]) = new ThermalCapacity(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "ThermalCapacity"

--- a/shared/src/main/scala/squants/time/Frequency.scala
+++ b/shared/src/main/scala/squants/time/Frequency.scala
@@ -56,7 +56,7 @@ final class Frequency private (val value: Double, val unit: FrequencyUnit)
   def toRevolutionsPerMinute = to(RevolutionsPerMinute)
 }
 
-object Frequency extends Dimension[Frequency] {
+implicit object Frequency extends Dimension[Frequency] {
   private[time] def apply[A](n: A, unit: FrequencyUnit)(implicit num: Numeric[A]) = new Frequency(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def name = "Frequency"

--- a/shared/src/main/scala/squants/time/Time.scala
+++ b/shared/src/main/scala/squants/time/Time.scala
@@ -42,7 +42,7 @@ final class Time private (val value: Double, val unit: TimeUnit)
   def toDays = to(Days)
 }
 
-object Time extends Dimension[Time] with BaseDimension {
+implicit object Time extends Dimension[Time] with BaseDimension {
   val NanosecondsPerSecond = 1.0e9
   val MicrosecondsPerSecond = 1.0e6
   val MillisecondsPerNanosecond = 1.0e-6


### PR DESCRIPTION
This makes all companion objects of `Quantity` classes that are `Dimension[Q]` to be implicit objects.

This solves typelevel/squants#320 and allows e.g. to write a single cats `Monoid` (or even `CommutativeGroup`) instance for all quantities (i.e. to have `def groupInstance[Q <: Quantity[Q]: Dimension]: Group[Q]` or so).