### PR TITLE
All dimensions were made to have implicit field equal to `this`.

### DIFF
--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -82,6 +82,8 @@ trait Dimension[A <: Quantity[A]] {
       case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit ${symbol}", s"(${Platform.crossFormat(num.toDouble(value))},${symbol})"))
     }
   }
+
+  implicit val dimensionImplicit: Dimension[A] = this
 }
 
 case class QuantityParseException(message: String, expression: String) extends Exception(s"$message:$expression")

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -702,4 +702,8 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers with TryVa
     timeInMinutes.hashCode() shouldBe timeInSeconds.hashCode()
 
   }
+
+  it should "provide implicit instance for Dimension" in {
+    implicitly[Dimension[Thingee]] shouldBe Thingee
+  }
 }

--- a/shared/src/test/scala/squants/time/FrequencySpec.scala
+++ b/shared/src/test/scala/squants/time/FrequencySpec.scala
@@ -16,7 +16,7 @@ import squants.mass.Kilograms
 import squants.motion._
 import squants.photo.{ LumenSeconds, Lumens, Lux, LuxSeconds }
 import squants.space.{ CubicMeters, Meters, Radians }
-import squants.{ Each, MetricSystem, QuantityParseException }
+import squants.{ Dimension, Each, MetricSystem, QuantityParseException }
 
 /**
  * @author  garyKeorkunian
@@ -101,5 +101,9 @@ class FrequencySpec extends FlatSpec with Matchers {
     d.gigahertz should be(Gigahertz(d))
     d.terahertz should be(Terahertz(d))
     d.rpm should be(RevolutionsPerMinute(d))
+  }
+
+  it should "provide implicit instance for Dimension" in {
+    implicitly[Dimension[Frequency]] shouldBe Frequency
   }
 }

--- a/shared/src/test/scala/squants/time/TimeSpec.scala
+++ b/shared/src/test/scala/squants/time/TimeSpec.scala
@@ -9,7 +9,7 @@
 package squants.time
 
 import org.scalatest.{ FlatSpec, Matchers }
-import squants.QuantityParseException
+import squants.{ Dimension, QuantityParseException }
 import squants.motion.{ MetersPerSecond, MetersPerSecondCubed, MetersPerSecondSquared }
 import squants.space.Meters
 
@@ -221,5 +221,9 @@ class TimeSpec extends FlatSpec with Matchers {
     def doSomethingWithDuration(duration: Duration): Unit = duration should be(Duration(10, SECONDS))
 
     doSomethingWithDuration(Seconds(10))
+  }
+
+  it should "provide implicit instance for Dimension" in {
+    implicitly[Dimension[Time]] shouldBe Time
   }
 }


### PR DESCRIPTION
This allows us to have nice implicit instance when `Dimension[Q]` is a
companion object to some quantity.

This solves #320 and allows e.g. to write a single cats' `Monoid` (or even `CommutativeGroup`) instance for all quantities (i.e. to have `def groupInstance[Q <: Quantity[Q]: Dimension]: Group[Q]` or so).