### PR TITLE
Allow currency parsing from implicit context

### DIFF
--- a/shared/src/main/scala/squants/market/MoneyContext.scala
+++ b/shared/src/main/scala/squants/market/MoneyContext.scala
@@ -32,6 +32,8 @@ case class MoneyContext(
     rates: Seq[CurrencyExchangeRate],
     allowIndirectConversions: Boolean = true) {
 
+  lazy val currencyMap = currencies.map { c: Currency ⇒ c.code -> c }.toMap
+
   /**
     * Custom implementation using SortedSets to ensure consistent output
     * @return String representation of this instance

--- a/shared/src/main/scala/squants/market/package.scala
+++ b/shared/src/main/scala/squants/market/package.scala
@@ -63,9 +63,12 @@ package object market {
     RUB, SEK, XAG, XAU, BTC,
     ETH, LTC, ZAR, NAD)
 
-  lazy val defaultCurrencyMap: Map[String, Currency] = defaultCurrencySet.map { c: Currency ⇒ c.code -> c }.toMap
-
   lazy val defaultMoneyContext = MoneyContext(USD, defaultCurrencySet, Nil)
 
   class NoSuchExchangeRateException(val s: String) extends Exception
+
+  case class NoSuchCurrencyException(code: String, fxContext: MoneyContext) extends Exception(
+    s"Code $code cannot be matched against any context defined Currency. " +
+      s"Available Currencies are ${fxContext.currencies.map(_.code).mkString(", ")}"
+  )
 }

--- a/shared/src/test/scala/squants/experimental/json/MoneySerializer.scala
+++ b/shared/src/test/scala/squants/experimental/json/MoneySerializer.scala
@@ -8,8 +8,8 @@
 
 package squants.experimental.json
 
-import org.json4s.{ Formats, Serializer }
-import squants.market.Money
+import org.json4s.{Formats, Serializer}
+import squants.market.{Money, MoneyContext}
 import org.json4s.JsonAST._
 import org.json4s.JsonAST.JString
 import org.json4s.reflect.TypeInfo
@@ -18,10 +18,8 @@ import org.json4s.JsonAST.JDecimal
 /**
  * Provides JSON serialization and deserialization for Money type
  */
-class MoneySerializer extends Serializer[Money] {
-
-  private val Clazz = classOf[Money]
-  case class MoneyData(amount: BigDecimal, currency: String)
+class MoneySerializer(fxContext: MoneyContext) extends Serializer[Money] {
+  import MoneySerializer._
 
   def deserialize(implicit format: Formats) = {
     case (TypeInfo(money, _), json) if Clazz.isAssignableFrom(money) ⇒ json match {
@@ -29,12 +27,12 @@ class MoneySerializer extends Serializer[Money] {
         JField("amount", JDecimal(_)),
         JField("currency", JString(_)))) ⇒
         val m = json.extract[MoneyData]
-        Money(m.amount, m.currency)
+        Money(m.amount, m.currency)(fxContext).get
       case JObject(List(
         JField("amount", JInt(_)),
         JField("currency", JString(_)))) ⇒
         val m = json.extract[MoneyData]
-        Money(m.amount, m.currency)
+        Money(m.amount, m.currency)(fxContext).get
     }
   }
 
@@ -45,4 +43,9 @@ class MoneySerializer extends Serializer[Money] {
           "amount" -> JDecimal(money.amount),
           "currency" -> JString(money.unit.code)))
   }
+}
+
+object MoneySerializer {
+  private val Clazz = classOf[Money]
+  private case class MoneyData(amount: BigDecimal, currency: String)
 }

--- a/shared/src/test/scala/squants/experimental/json/QuantitySerializerSpec.scala
+++ b/shared/src/test/scala/squants/experimental/json/QuantitySerializerSpec.scala
@@ -22,12 +22,12 @@ class QuantitySerializerSpec extends FlatSpec with MustMatchers {
   object QuantitySerializerMarshaller {
     implicit val formats = DefaultFormats.withBigDecimal +
       new PowerSerializer +
-      new EnergyPriceSerializer +
-      new MassPriceSerializer +
-      new MoneySerializer +
+      new EnergyPriceSerializer(defaultMoneyContext) +
+      new MassPriceSerializer(defaultMoneyContext) +
+      new MoneySerializer(defaultMoneyContext) +
       new TimeSerializer +
       new MassSerializer +
-      new TimePriceSerializer
+      new TimePriceSerializer(defaultMoneyContext)
   }
 
   behavior of "QuantitySerializer"

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -13,8 +13,8 @@ import squants.QuantityParseException
 import squants.mass.Kilograms
 import squants.space.Meters
 import squants.time.Hours
-
 import scala.math.BigDecimal.RoundingMode
+import scala.util.{Failure, Success}
 
 /**
  * @author  garyKeorkunian
@@ -25,14 +25,22 @@ class MoneySpec extends FlatSpec with Matchers {
 
   behavior of "Money and its Units of Measure"
 
+  it should "create Currency values from currency string codes given an implicit MoneyContext in scope" in {
+    implicit val moneyContext = MoneyContext(USD, defaultCurrencySet, Nil)
+    Currency("USD") should be(Success(USD))
+    Currency("NAD") should be(Success(NAD))
+    Currency("DUM") should be(Failure(NoSuchCurrencyException("DUM", moneyContext)))
+  }
+
   it should "create values using factories that take Currency" in {
     Money(BigDecimal(10), USD) should be(Money(10, USD))
     Money(10, USD) should be(Money(10, USD))
   }
 
-  it should "create values using factories that take Currency Code (String)" in {
-    Money(BigDecimal(10), "USD") should be(Money(10, USD))
-    Money(10, "USD") should be(Money(10, USD))
+  it should "create values using factories that take Currency Code (String) and an implicit MoneyContext in scope" in {
+    implicit val moneyContext = MoneyContext(USD, defaultCurrencySet, Nil)
+    Money(BigDecimal(10), "USD") should be(Success(Money(10, USD)))
+    Money(10, "USD") should be(Success(Money(10, USD)))
   }
 
   it should "create values using Currency (UOM) factories" in {
@@ -46,7 +54,8 @@ class MoneySpec extends FlatSpec with Matchers {
     Money(10) should be(USD(10))
   }
 
-  it should "create values from formatted strings" in {
+  it should "create values from formatted strings given an implicit MoneyContext in scope" in {
+    implicit val moneyContext = MoneyContext(USD, defaultCurrencySet, Nil)
     Money("500 USD").get should be(USD(500))
     Money("500USD").get should be(USD(500))
     Money("5.50USD").get should be(USD(5.5))
@@ -506,7 +515,7 @@ class MoneySpec extends FlatSpec with Matchers {
   }
 
   it should "return quantity when dividing by price" in {
-    val p = Price(Money(10, "USD"), Meters(1))
-    Money(40, "USD") / p should be(Meters(4))
+    val p = Price(Money(10, USD), Meters(1))
+    Money(40, USD) / p should be(Meters(4))
   }
 }

--- a/shared/src/test/scala/squants/market/PriceSpec.scala
+++ b/shared/src/test/scala/squants/market/PriceSpec.scala
@@ -21,78 +21,78 @@ class PriceSpec extends FlatSpec with Matchers {
   behavior of "Price and its Units of Measure"
 
   it should "create Price objects using the primary constructor" in {
-    val p = Price(Money(100, "USD"), Meters(1))
-    p.money should be(Money(100, "USD"))
+    val p = Price(Money(100, USD), Meters(1))
+    p.money should be(Money(100, USD))
     p.quantity should be(Meters(1))
   }
 
   it should "properly add two like prices" in {
-    val p1 = Price(Money(5, "USD"), Meters(1))
-    val p2 = Price(Money(8, "USD"), Meters(1))
-    val p3 = Price(Money(13, "USD"), Meters(1))
+    val p1 = Price(Money(5, USD), Meters(1))
+    val p2 = Price(Money(8, USD), Meters(1))
+    val p3 = Price(Money(13, USD), Meters(1))
     p3 should be(p1 + p2)
   }
 
   it should "properly subtract two like prices" in {
-    val p1 = Price(Money(15, "USD"), Meters(1))
-    val p2 = Price(Money(8, "USD"), Meters(1))
-    val p3 = Price(Money(7, "USD"), Meters(1))
+    val p1 = Price(Money(15, USD), Meters(1))
+    val p2 = Price(Money(8, USD), Meters(1))
+    val p3 = Price(Money(7, USD), Meters(1))
     p3 should be(p1 - p2)
   }
 
   it should "properly multiply by a Double" in {
-    val p1 = Price(Money(9, "USD"), Meters(1))
-    val p2 = Price(Money(3, "USD"), Meters(1))
+    val p1 = Price(Money(9, USD), Meters(1))
+    val p2 = Price(Money(3, USD), Meters(1))
     p1 should be(p2 * 3)
   }
 
   it should "properly multiply by a BigDecimal" in {
-    val p1 = Price(Money(9, "USD"), Meters(1))
-    val p2 = Price(Money(3, "USD"), Meters(1))
+    val p1 = Price(Money(9, USD), Meters(1))
+    val p2 = Price(Money(3, USD), Meters(1))
     p1 should be(p2 * BigDecimal(3))
   }
 
   it should "properly divide by a Double" in {
-    val p1 = Price(Money(9, "USD"), Meters(1))
-    val p2 = Price(Money(3, "USD"), Meters(1))
+    val p1 = Price(Money(9, USD), Meters(1))
+    val p2 = Price(Money(3, USD), Meters(1))
     p2 should be(p1 / 3)
   }
 
   it should "properly divide by a BigDecimal" in {
-    val p1 = Price(Money(9, "USD"), Meters(1))
-    val p2 = Price(Money(3, "USD"), Meters(1))
+    val p1 = Price(Money(9, USD), Meters(1))
+    val p2 = Price(Money(3, USD), Meters(1))
     p2 should be(p1 / BigDecimal(3))
   }
 
   it should "properly divide by a like Price" in {
-    val p1 = Price(Money(9, "USD"), Meters(1))
-    val p2 = Price(Money(3, "USD"), Meters(1))
+    val p1 = Price(Money(9, USD), Meters(1))
+    val p2 = Price(Money(3, USD), Meters(1))
     p1 / p2 should be(BigDecimal(3))
     (p1 / p2).toDouble should be(3)
   }
 
   it should "properly multiply by Quantity using BigDecimal arithmetic" in {
-    val p1 = Price(Money(BigDecimal("0.3"), "USD"), Meters(1))
-    p1 * Meters(3) should be(Money(BigDecimal("0.9"), "USD"))
+    val p1 = Price(Money(BigDecimal("0.3"), USD), Meters(1))
+    p1 * Meters(3) should be(Money(BigDecimal("0.9"), USD))
   }
 
   it should "return Money when multiplied by Quantity" in {
-    val p = Price(Money(10, "USD"), Meters(1))
-    p * Meters(10) should be(Money(100, "USD"))
+    val p = Price(Money(10, USD), Meters(1))
+    p * Meters(10) should be(Money(100, USD))
   }
 
   it should "return Quantity when divided by Money" in {
-    val p = Price(Money(10, "USD"), Meters(1))
-    Money(40, "USD") / p should be(Meters(4))
+    val p = Price(Money(10, USD), Meters(1))
+    Money(40, USD) / p should be(Meters(4))
   }
 
   it should "return properly formatted strings" in {
-    val p = Price(Money(10.22, "USD"), Meters(1))
+    val p = Price(Money(10.22, USD), Meters(1))
     p.toString should be(p.money.toString + "/" + p.quantity.toString)
   }
 
   it should "return a properly formatted string in terms of the given unit" in {
-    val p = Price(Money(10.22, "USD"), Meters(1))
+    val p = Price(Money(10.22, USD), Meters(1))
     p.toString(Yards) should be(p.money.toString + "/" + p.quantity.toString(Yards))
   }
 


### PR DESCRIPTION
This PR adds a companion object to `Currency` whose `apply` receives a currency code String, an implicit `MoneyContext` and returns a `Try[Currency]`.

It also changes the methods in `Money` companion that used to parse a currency from a String and relied solely on the `defaultMoneyContext`  to fetch the corresponding `Currency` value:  these methods now receive an implicit `MoneyContext` and use the new `Currency.apply` which, I think, should solve #296.

For my use case, these modifications are useful when working with domain models that specify some `Currency`, that must be parsed from JSON, and when loading `Currency` from typesafe config (using PureConfig). 