### PR TITLE
EnergyDensity: symbol changed from j/m³ to J/m³

### DIFF
--- a/shared/src/main/scala/squants/energy/EnergyDensity.scala
+++ b/shared/src/main/scala/squants/energy/EnergyDensity.scala
@@ -9,6 +9,7 @@
 package squants.energy
 
 import squants._
+import squants.space.CubicMeters
 
 /**
  * Represents a quantity of energy
@@ -42,7 +43,7 @@ trait EnergyDensityUnit extends UnitOfMeasure[EnergyDensity] with UnitConverter 
 }
 
 object JoulesPerCubicMeter extends EnergyDensityUnit with PrimaryUnit with SiUnit {
-  val symbol = "j/m³"
+  val symbol = Joules.symbol + "/" + CubicMeters.symbol
 }
 
 object EnergyDensityConversions {

--- a/shared/src/test/scala/squants/energy/EnergyDensitySpec.scala
+++ b/shared/src/test/scala/squants/energy/EnergyDensitySpec.scala
@@ -26,9 +26,9 @@ class EnergyDensitySpec extends FlatSpec with Matchers {
   }
 
   it should "create values from properly formatted Strings" in {
-    EnergyDensity("10.22 j/m³").get should be(JoulesPerCubicMeter(10.22))
+    EnergyDensity("10.22 J/m³").get should be(JoulesPerCubicMeter(10.22))
     EnergyDensity("10.22 zz").failed.get should be(QuantityParseException("Unable to parse EnergyDensity", "10.22 zz"))
-    EnergyDensity("ZZ j/m³").failed.get should be(QuantityParseException("Unable to parse EnergyDensity", "ZZ j/m³"))
+    EnergyDensity("ZZ J/m³").failed.get should be(QuantityParseException("Unable to parse EnergyDensity", "ZZ J/m³"))
   }
 
   it should "properly convert to all supported Units of Measure" in {
@@ -38,7 +38,7 @@ class EnergyDensitySpec extends FlatSpec with Matchers {
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
-    JoulesPerCubicMeter(1).toString(JoulesPerCubicMeter) should be("1.0 j/m³")
+    JoulesPerCubicMeter(1).toString(JoulesPerCubicMeter) should be("1.0 J/m³")
   }
 
   it should "return Energy when multiplied by Volume" in {


### PR DESCRIPTION
correct symbol for Joule is upper case J