### PR TITLE
Remove hardcoded dependency on default money context

### DIFF
--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -387,15 +387,15 @@ object Money extends Dimension[Money] {
   def apply(value: BigDecimal)(implicit fxContext: MoneyContext) = new Money(value)(fxContext.defaultCurrency)
 
   def apply(value: BigDecimal, currency: Currency) = new Money(value)(currency)
-  def apply(value: BigDecimal, currency: String) = new Money(value)(defaultCurrencyMap(currency))
+  def apply(value: BigDecimal, currency: String)(implicit context: MoneyContext) = new Money(value)(context.currencyMap(currency))
 
   def apply[A](n: A, currency: Currency)(implicit num: Numeric[A]) = new Money(BigDecimal(num.toDouble(n)))(currency)
-  def apply[A](n: A, currency: String)(implicit num: Numeric[A]) = new Money(BigDecimal(num.toDouble(n)))(defaultCurrencyMap(currency))
+  def apply[A](n: A, currency: String)(implicit num: Numeric[A], context: MoneyContext) = new Money(BigDecimal(num.toDouble(n)))(context.currencyMap(currency))
 
-  def apply(s: String): Try[Money] = {
-    lazy val regex = ("([-+]?[0-9]*\\.?[0-9]+) *(" + defaultCurrencySet.map(_.code).reduceLeft(_ + "|" + _) + ")").r
+  def apply(s: String)(implicit context: MoneyContext): Try[Money] = {
+    lazy val regex = ("([-+]?[0-9]*\\.?[0-9]+) *(" + context.currencies.map(_.code).reduceLeft(_ + "|" + _) + ")").r
     s match {
-      case regex(value, currency) ⇒ Success(Money(value.toDouble, defaultCurrencyMap(currency)))
+      case regex(value, currency) ⇒ Success(Money(value.toDouble, context.currencyMap(currency)))
       case _                      ⇒ Failure(QuantityParseException("Unable to parse Money", s))
     }
   }

--- a/shared/src/main/scala/squants/market/MoneyContext.scala
+++ b/shared/src/main/scala/squants/market/MoneyContext.scala
@@ -30,7 +30,10 @@ case class MoneyContext(
     defaultCurrency: Currency,
     currencies: Set[Currency],
     rates: Seq[CurrencyExchangeRate],
-    allowIndirectConversions: Boolean = true) {
+    allowIndirectConversions: Boolean = true
+) {
+
+  lazy val currencyMap: Map[String, Currency] = currencies.map { c: Currency ⇒ c.code → c }.toMap
 
   /**
     * Custom implementation using SortedSets to ensure consistent output

--- a/shared/src/main/scala/squants/market/package.scala
+++ b/shared/src/main/scala/squants/market/package.scala
@@ -63,8 +63,6 @@ package object market {
     RUB, SEK, XAG, XAU, BTC,
     ETH, LTC, ZAR, NAD)
 
-  lazy val defaultCurrencyMap: Map[String, Currency] = defaultCurrencySet.map { c: Currency ⇒ c.code -> c }.toMap
-
   lazy val defaultMoneyContext = MoneyContext(USD, defaultCurrencySet, Nil)
 
   class NoSuchExchangeRateException(val s: String) extends Exception

--- a/shared/src/test/scala/squants/experimental/json/MoneySerializer.scala
+++ b/shared/src/test/scala/squants/experimental/json/MoneySerializer.scala
@@ -9,7 +9,7 @@
 package squants.experimental.json
 
 import org.json4s.{ Formats, Serializer }
-import squants.market.Money
+import squants.market.{ defaultMoneyContext, Money}
 import org.json4s.JsonAST._
 import org.json4s.JsonAST.JString
 import org.json4s.reflect.TypeInfo
@@ -22,6 +22,7 @@ class MoneySerializer extends Serializer[Money] {
 
   private val Clazz = classOf[Money]
   case class MoneyData(amount: BigDecimal, currency: String)
+  implicit val moneyContext = defaultMoneyContext
 
   def deserialize(implicit format: Formats) = {
     case (TypeInfo(money, _), json) if Clazz.isAssignableFrom(money) ⇒ json match {

--- a/shared/src/test/scala/squants/experimental/json/PriceSerializer.scala
+++ b/shared/src/test/scala/squants/experimental/json/PriceSerializer.scala
@@ -10,11 +10,10 @@ package squants.experimental.json
 
 import squants.Quantity
 import org.json4s.{ Formats, Serializer }
-import squants.market.Money
+import squants.market.{ Money, Price, defaultMoneyContext }
 import org.json4s.JsonAST._
 import squants.energy._
 import squants.time.Time
-import squants.market.Price
 import org.json4s.JsonAST.JString
 import org.json4s.reflect.TypeInfo
 import org.json4s.JsonAST.JInt
@@ -32,6 +31,7 @@ trait PriceSerializerT[A <: Quantity[A]] extends Serializer[Price[A]] {
   def parseQuantity: String ⇒ Try[A]
   private def QuantityValidator(s: String) = parseQuantity(s).isSuccess
   private def StringToQuantity(s: String) = parseQuantity(s).get
+  implicit val moneyContext = defaultMoneyContext
 
   /**
    * Implementation

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -31,6 +31,7 @@ class MoneySpec extends FlatSpec with Matchers {
   }
 
   it should "create values using factories that take Currency Code (String)" in {
+    implicit val moneyContext = defaultMoneyContext
     Money(BigDecimal(10), "USD") should be(Money(10, USD))
     Money(10, "USD") should be(Money(10, USD))
   }
@@ -47,6 +48,7 @@ class MoneySpec extends FlatSpec with Matchers {
   }
 
   it should "create values from formatted strings" in {
+    implicit val moneyContext = defaultMoneyContext
     Money("500 USD").get should be(USD(500))
     Money("500USD").get should be(USD(500))
     Money("5.50USD").get should be(USD(5.5))
@@ -506,6 +508,7 @@ class MoneySpec extends FlatSpec with Matchers {
   }
 
   it should "return quantity when dividing by price" in {
+    implicit val moneyContext = defaultMoneyContext
     val p = Price(Money(10, "USD"), Meters(1))
     Money(40, "USD") / p should be(Meters(4))
   }

--- a/shared/src/test/scala/squants/market/PriceSpec.scala
+++ b/shared/src/test/scala/squants/market/PriceSpec.scala
@@ -18,6 +18,8 @@ import squants.space.{ Yards, Meters }
  */
 class PriceSpec extends FlatSpec with Matchers {
 
+  implicit val moneyContext = defaultMoneyContext
+
   behavior of "Price and its Units of Measure"
 
   it should "create Price objects using the primary constructor" in {


### PR DESCRIPTION
Squants market package is designed to allow defining a different set of currencies, with optional FX rates.

This flexibility is achieved by using an implicit `MoneyContext` parameter on some methods, with a default value set to `squants.market.defaultMoneyContext`. This way, one can define a new `MoneyContext`, and mark it implicit to have it used instead of the default.

This however isn't consistently implemented throughout the code base. It is especially missing on factory methods of the `Money` object which involve parsing a currency code. As a consequence, one cannot build `Money` instances using custom currencies (i.e., currencies which are not available in the squants market package).

This pull request is meant to fix this issue. It does so by removing any hard-coded references to the default currency set or default money context, and replacing them by an implicitly passed `MoneyContext`.