### PR TITLE
#323 adding hashcode to Money

### DIFF
--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -14,6 +14,7 @@ import scala.util.{Failure, Success, Try}
 import scala.language.implicitConversions
 import scala.math.BigDecimal.RoundingMode
 import scala.math.BigDecimal.RoundingMode.RoundingMode
+import java.util.Objects
 
 /**
  * Represents a quantity of Money.
@@ -259,6 +260,12 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
   }
 
   /**
+   * Override for Quantity.hashCode because Money doesn't contain a primary unit
+   * @return
+   */
+  override def hashCode = java.util.Objects.hash(amount, currency)
+
+  /**
    * Override for Quantity.compare to only work on Moneys of like Currency
    * @param that Money
    * @return Int
@@ -377,6 +384,9 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
     * @return Money
     */
   def mapAmount(f: BigDecimal => BigDecimal) = currency(f(amount))
+
+
+
 }
 
 /**

--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -263,7 +263,7 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * Override for Quantity.hashCode because Money doesn't contain a primary unit
    * @return
    */
-  override def hashCode = java.util.Objects.hash(amount, currency)
+  override def hashCode: Int = Objects.hash(amount, currency)
 
   /**
    * Override for Quantity.compare to only work on Moneys of like Currency
@@ -384,9 +384,6 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
     * @return Money
     */
   def mapAmount(f: BigDecimal => BigDecimal) = currency(f(amount))
-
-
-
 }
 
 /**

--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -343,6 +343,7 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
     case this.currency ⇒ throw new IllegalArgumentException("Can not create Exchange Rate on matching currencies")
     case _             ⇒ CurrencyExchangeRate(that, this)
   }
+
   /**
    * toThe
    */

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -9,19 +9,18 @@
 package squants.market
 
 import org.scalatest.{FlatSpec, Matchers}
-import squants.{QuantityParseException, Seconds}
+import squants.QuantityParseException
 import squants.mass.Kilograms
 import squants.space.Meters
-import squants.time.{Hours, Minutes}
-
+import squants.time.Hours
 import scala.math.BigDecimal.RoundingMode
 import scala.util.{Failure, Success}
 
 /**
-  * @author  garyKeorkunian
-  * @since   0.1
-  *
-  */
+ * @author  garyKeorkunian
+ * @since   0.1
+ *
+ */
 class MoneySpec extends FlatSpec with Matchers {
 
   behavior of "Money and its Units of Measure"
@@ -63,9 +62,7 @@ class MoneySpec extends FlatSpec with Matchers {
     Money("500 EUR").get should be(EUR(500))
     Money("10000.0 JPY").get should be(JPY(10000))
     Money("23.45 CAD").get should be(CAD(23.45))
-    Money("23.45 ZZZ").failed.get should be(
-      QuantityParseException("Unable to parse Money", "23.45 ZZZ")
-    )
+    Money("23.45 ZZZ").failed.get should be(QuantityParseException("Unable to parse Money", "23.45 ZZZ"))
   }
 
   it should "return proper result when comparing like currencies" in {
@@ -268,6 +265,8 @@ class MoneySpec extends FlatSpec with Matchers {
     USD(10) * BigDecimal(2) should be(USD(20))
     JPY(23.50) * BigDecimal(3) should be(JPY(70.50))
   }
+
+
 
   it should "return proper results when multiplying by mix of BigDecimal, Double and Int" in {
     val x: Double = 2
@@ -504,8 +503,7 @@ class MoneySpec extends FlatSpec with Matchers {
   it should "provide Numeric support within a MoneyContext with applicable Exchange Rates" in {
     import MoneyConversions._
 
-    implicit val moneyContext =
-      defaultMoneyContext.withExchangeRates(List(USD(1) -> CAD(10), USD(1) -> JPY(100)))
+    implicit val moneyContext = defaultMoneyContext.withExchangeRates(List(USD(1) -> CAD(10), USD(1) -> JPY(100)))
     implicit val moneyNum = new MoneyNumeric()
 
     val ms = List(USD(100), USD(10), USD(1))

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -9,18 +9,19 @@
 package squants.market
 
 import org.scalatest.{FlatSpec, Matchers}
-import squants.QuantityParseException
+import squants.{QuantityParseException, Seconds}
 import squants.mass.Kilograms
 import squants.space.Meters
-import squants.time.Hours
+import squants.time.{Hours, Minutes}
+
 import scala.math.BigDecimal.RoundingMode
 import scala.util.{Failure, Success}
 
 /**
- * @author  garyKeorkunian
- * @since   0.1
- *
- */
+  * @author  garyKeorkunian
+  * @since   0.1
+  *
+  */
 class MoneySpec extends FlatSpec with Matchers {
 
   behavior of "Money and its Units of Measure"
@@ -62,7 +63,9 @@ class MoneySpec extends FlatSpec with Matchers {
     Money("500 EUR").get should be(EUR(500))
     Money("10000.0 JPY").get should be(JPY(10000))
     Money("23.45 CAD").get should be(CAD(23.45))
-    Money("23.45 ZZZ").failed.get should be(QuantityParseException("Unable to parse Money", "23.45 ZZZ"))
+    Money("23.45 ZZZ").failed.get should be(
+      QuantityParseException("Unable to parse Money", "23.45 ZZZ")
+    )
   }
 
   it should "return proper result when comparing like currencies" in {
@@ -149,6 +152,12 @@ class MoneySpec extends FlatSpec with Matchers {
     x.equals(y) should be(right = false)
     x == y should be(right = false)
     x != y should be(right = true)
+  }
+
+  it should "return consistent hashcode" in {
+    val someMoney = USD(2.1)
+
+    someMoney.hashCode() shouldBe someMoney.hashCode()
   }
 
   it should "return a proper result on max/min operation with an implicit MoneyContext in scope" in {
@@ -259,8 +268,6 @@ class MoneySpec extends FlatSpec with Matchers {
     USD(10) * BigDecimal(2) should be(USD(20))
     JPY(23.50) * BigDecimal(3) should be(JPY(70.50))
   }
-
-
 
   it should "return proper results when multiplying by mix of BigDecimal, Double and Int" in {
     val x: Double = 2
@@ -497,7 +504,8 @@ class MoneySpec extends FlatSpec with Matchers {
   it should "provide Numeric support within a MoneyContext with applicable Exchange Rates" in {
     import MoneyConversions._
 
-    implicit val moneyContext = defaultMoneyContext.withExchangeRates(List(USD(1) -> CAD(10), USD(1) -> JPY(100)))
+    implicit val moneyContext =
+      defaultMoneyContext.withExchangeRates(List(USD(1) -> CAD(10), USD(1) -> JPY(100)))
     implicit val moneyNum = new MoneyNumeric()
 
     val ms = List(USD(100), USD(10), USD(1))


### PR DESCRIPTION
PR to solve bug #323.
This makes it possible to use Money and Price objects correctly in Sets/Maps. Or when these objects are nested in a case class