### PR TITLE
Remove scala 2.10 and cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.9
-
-dist: trusty
+  - 2.12.10
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
 
 branches:
@@ -43,14 +41,3 @@ script:
   - if [[ $TRAVIS_SCALA_VERSION == "2.11.12" ]]; then sbt ++$TRAVIS_SCALA_VERSION squantsNative/compile; fi;
   - if [[ $SCALAJS_VERSION == "0.6.29" ]]; then sbt ++$TRAVIS_SCALA_VERSION squantsJS/test; fi;
   - sbt ++$TRAVIS_SCALA_VERSION squantsJVM/test
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
-notifications:
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/e50c1534becaa7b20529
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: always

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ lazy val squants =
     osgiSettings,
     scalacOptions in Tut --= Seq("-Ywarn-unused-import", "-Ywarn-unused:imports"),
     tutTargetDirectory := file("."),
-    tutSourceDirectory := file("shared") / "src" / "main" / "tut"
+    tutSourceDirectory := file("shared") / "src" / "main" / "tut",
+    parallelExecution in Test := false
   )
   .jvmSettings(Tests.defaultSettings: _*)
   .jsSettings(Tests.defaultSettings: _*)
@@ -35,7 +36,8 @@ lazy val squants =
     sources in (Compile, test) := List() // This is a pity but we can't reliable compile on 1.0.0-M8
   )
   .nativeSettings(
-    sources in (Compile, doc) := List() // Can't build docs in native
+    sources in (Compile, doc) := List(), // Can't build docs in native
+    sources in (Compile, test) := List() // Can't yet compile in native
   )
 
 lazy val root = project.in(file("."))
@@ -43,7 +45,6 @@ lazy val root = project.in(file("."))
   .settings(
     name := "squants",
     publish := {},
-    publishLocal := {},
-    useGpg := true
+    publishLocal := {}
   )
   .aggregate(squants.jvm, squants.js, squants.native)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,20 +12,14 @@ object Versions {
   val scalaJSVersion =
     Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.29")
   val ScalaCross =
-    if (scalaJSVersion.startsWith("0.6")) {
-      Seq("2.10.7", "2.11.12", "2.12.9")
-    } else {
-      Seq("2.11.12", "2.12.9")
-    }
+    Seq("2.11.12", "2.12.10")
 
   val ScalaTest = "3.1.0-M2"
-  val ScalaTestOld = "3.0.7"
-  val ScalaCheck = "1.13.5"
+  val ScalaCheck = "1.14.0"
   val Json4s = "3.6.7"
 }
 
 object Dependencies {
-  val scalaTestOld = Def.setting(Seq("org.scalatest" %%% "scalatest" % Versions.ScalaTestOld % Test))
   val scalaTest = Def.setting(Seq("org.scalatest" %%% "scalatest" % Versions.ScalaTest % Test))
   val scalaCheck = Def.setting(Seq("org.scalacheck" %%% "scalacheck" % Versions.ScalaCheck % Test))
   val json4s = Def.setting(Seq("org.json4s" %% "json4s-native" % Versions.Json4s % Test))
@@ -79,8 +73,7 @@ object Compiler {
     "-Xfatal-warnings",
     "-unchecked",
     "-Xfuture",
-    "-Ywarn-dead-code",
-    "-Yno-adapted-args"
+    "-Ywarn-dead-code"
   )
 
   lazy val defaultSettings = Seq(


### PR DESCRIPTION
This PR removes support for 2.10 thus simplifying a bit the build and it contains other small build cleanups
It also seems to fix #356 