### PR TITLE
2.13: Add Numeric.parseOption implementations

### DIFF
--- a/shared/src/main/scala/squants/AbstractQuantityNumeric.scala
+++ b/shared/src/main/scala/squants/AbstractQuantityNumeric.scala
@@ -37,4 +37,5 @@ abstract class AbstractQuantityNumeric[A <: Quantity[A]](val unit: UnitOfMeasure
   def toFloat(x: A) = x.to(unit).toFloat
   def toDouble(x: A) = x.to(unit)
   def compare(x: A, y: A) = if (x.to(unit) > y.to(unit)) 1 else if (x.to(unit) < y.to(unit)) -1 else 0
+  def parseString(str: String): Option[A] = unit(0).dimension.parseString(str).toOption
 }

--- a/shared/src/main/scala/squants/AbstractQuantityNumeric.scala
+++ b/shared/src/main/scala/squants/AbstractQuantityNumeric.scala
@@ -37,5 +37,7 @@ abstract class AbstractQuantityNumeric[A <: Quantity[A]](val unit: UnitOfMeasure
   def toFloat(x: A) = x.to(unit).toFloat
   def toDouble(x: A) = x.to(unit)
   def compare(x: A, y: A) = if (x.to(unit) > y.to(unit)) 1 else if (x.to(unit) < y.to(unit)) -1 else 0
+  // As there's no direct access to the Dimension (which has parseString) from a UnitOfMeasure, 
+  // we create a dummy instance here and access its dimension member
   def parseString(str: String): Option[A] = unit(0).dimension.parseString(str).toOption
 }

--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -525,6 +525,7 @@ object MoneyConversions {
     def toFloat(x: Money) = x.value.toFloat
     def toDouble(x: Money) = x.value
     def compare(x: Money, y: Money) = if (x.value > y.value) 1 else if (x.value < y.value) -1 else 0
+    def parseString(str: String): Option[Money] = Money(str).toOption
 
     /**
       * Custom implementation using SortedSets to ensure consistent output

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -74,6 +74,7 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers with TryVa
     implicit val stringNumeric = new BaseNumeric[String] {
       def fromInt(x: Int) = x.toString
       def toDouble(x: String) = augmentString(x).toDouble // augmentString is used to disambiguate implicit conversion
+      def parseString(str: String): Option[String] = Some(str) // for 2.13 compability
     }
 
     // Use them to initialize quantity values


### PR DESCRIPTION
As Scala added `parseOption` to `Numeric` in 2.13 and we define our own `Numeric` instances, we have to add `parseOption` here as well. Implementations are delegating to the existing code to maintain consistency.

Edit: This is part of what's needed for #344.