### PR TITLE
Enable scala 2.13 (fixing #344)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ scala:
 
 jdk:
   - openjdk8
-  - openjdk11
+  - oraclejdk11
+  # can be switched back to openjdk once Travis uses 11.0.3 fixing https://bugs.openjdk.java.net/browse/JDK-8208275
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: scala
 scala:
   - 2.11.12
   - 2.12.10
+  - 2.13.1
 
 jdk:
   - openjdk8

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Versions {
     Seq("2.11.12", "2.12.10", "2.13.1")
 
   val ScalaTest = "3.1.0-RC3"
-  val ScalaCheck = "1.14.0"
+  val ScalaCheck = "1.14.1"
   val Json4s = "3.6.7"
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ object Versions {
   val scalaJSVersion =
     Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
   val ScalaCross =
-    Seq("2.11.12", "2.12.10")
+    Seq("2.11.12", "2.12.10", "2.13.1")
 
   val ScalaTest = "3.1.0-RC3"
   val ScalaCheck = "1.14.0"
@@ -61,7 +61,6 @@ object Compiler {
   lazy val newerCompilerLintSwitches = Seq(
     "-Xlint:missing-interpolator",
     "-Ywarn-unused",
-    "-Ywarn-unused-import",
     "-Ywarn-numeric-widen",
     "-deprecation:false"
   )
@@ -83,7 +82,8 @@ object Compiler {
       "-encoding", "UTF-8",
     ),
     scalacOptions := {CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, scalaMajor)) if scalaMajor >= 11 => scalacOptions.value ++ defaultCompilerSwitches ++ newerCompilerLintSwitches
+      case Some((2, scalaMajor)) if scalaMajor >= 13 => scalacOptions.value ++ defaultCompilerSwitches ++ newerCompilerLintSwitches
+      case Some((2, scalaMajor)) if scalaMajor >= 11 => scalacOptions.value ++ defaultCompilerSwitches ++ newerCompilerLintSwitches :+ "-Ywarn-unused-import"
       case _ => scalacOptions.value ++ defaultCompilerSwitches
     }},
 

--- a/shared/src/main/scala/squants/energy/Energy.scala
+++ b/shared/src/main/scala/squants/energy/Energy.scala
@@ -36,7 +36,7 @@ final class Energy private (val value: Double, val unit: EnergyUnit)
   protected def time = Hours(1)
 
   def *(that: ParticleFlux): Irradiance = WattsPerSquareMeter(
-    Hours(1).toSeconds * this.toWattHours * 
+    Hours(1).toSeconds * this.toWattHours *
       that.toBecquerelsPerSquareMeterSecond)
   def /(that: Length): Force = Newtons(this.toJoules / that.toMeters)
   def /(that: Force): Length = Meters(this.toJoules / that.toNewtons)

--- a/shared/src/main/scala/squants/energy/package.scala
+++ b/shared/src/main/scala/squants/energy/package.scala
@@ -16,10 +16,10 @@ package squants
 package object energy {
 
   object KineticEnergy {
-    def apply(mass: Mass, velocity: Velocity): Energy =
+    def apply(mass: Mass, velocity: squants.motion.Velocity): Energy =
       Joules(0.5 * mass.toKilograms * velocity.toMetersPerSecond * velocity.toMetersPerSecond)
 
-    def apply(mass: Mass, momentum: Momentum): Energy =
+    def apply(mass: Mass, momentum: squants.motion.Momentum): Energy =
       Joules(momentum.toNewtonSeconds / (mass.toKilograms * 2.0))
 
   }

--- a/shared/src/main/scala/squants/motion/Acceleration.scala
+++ b/shared/src/main/scala/squants/motion/Acceleration.scala
@@ -8,9 +8,10 @@
 
 package squants.motion
 
-import squants._
-import squants.space.{ Feet, Millimeters, UsMiles }
-import squants.time.{ Seconds, TimeDerivative, TimeIntegral, SecondTimeDerivative, TimeSquared, Time }
+import squants.{AbstractQuantityNumeric, Dimension, PrimaryUnit, Quantity, SiUnit, UnitConverter, UnitOfMeasure}
+import squants.mass.Mass
+import squants.space.{Feet, Length, Meters, Millimeters, UsMiles}
+import squants.time.{SecondTimeDerivative, Seconds, Time, TimeDerivative, TimeIntegral, TimeSquared}
 
 /**
  * Represents a quantity of acceleration

--- a/shared/src/main/scala/squants/motion/Momentum.scala
+++ b/shared/src/main/scala/squants/motion/Momentum.scala
@@ -8,9 +8,9 @@
 
 package squants.motion
 
-import squants._
-import squants.mass.Kilograms
-import squants.time.{ SecondTimeIntegral, Seconds, TimeIntegral, TimeSquared }
+import squants.{AbstractQuantityNumeric, Dimension, PrimaryUnit, Quantity, SiUnit, UnitOfMeasure}
+import squants.mass.{Kilograms, Mass}
+import squants.time.{SecondTimeIntegral, Seconds, TimeIntegral, TimeSquared}
 
 /**
  * @author  garyKeorkunian

--- a/shared/src/main/scala/squants/motion/Velocity.scala
+++ b/shared/src/main/scala/squants/motion/Velocity.scala
@@ -8,9 +8,10 @@
 
 package squants.motion
 
-import squants.{ Time, _ }
-import squants.space.{ Feet, InternationalMiles, Kilometers, Millimeters, NauticalMiles, UsMiles }
-import squants.time.{ Seconds, _ }
+import squants.mass.Mass
+import squants.space._
+import squants.time._
+import squants.{AbstractQuantityNumeric, Dimension, PrimaryUnit, Quantity, SiUnit, UnitConverter, UnitOfMeasure}
 
 /**
  * Represents a quantify of Velocity

--- a/shared/src/test/scala-2.11/squants/experimental/ScalaVersionSpecificNumericInstances.scala
+++ b/shared/src/test/scala-2.11/squants/experimental/ScalaVersionSpecificNumericInstances.scala
@@ -1,0 +1,10 @@
+package squants.experimental
+
+import squants.experimental.SquantsNumeric.{DoubleIsSquantsNumeric, FloatIsSquantsNumeric}
+
+trait ScalaVersionSpecificNumericInstances {
+
+  implicit object FloatIsSquantsNumeric extends FloatIsSquantsNumeric with Ordering.FloatOrdering
+  implicit object DoubleIsSquantsNumeric extends DoubleIsSquantsNumeric with Ordering.DoubleOrdering
+
+}

--- a/shared/src/test/scala-2.12/squants/experimental/ScalaVersionSpecificNumericInstances.scala
+++ b/shared/src/test/scala-2.12/squants/experimental/ScalaVersionSpecificNumericInstances.scala
@@ -1,0 +1,10 @@
+package squants.experimental
+
+import squants.experimental.SquantsNumeric.{DoubleIsSquantsNumeric, FloatIsSquantsNumeric}
+
+trait ScalaVersionSpecificNumericInstances {
+
+  implicit object FloatIsSquantsNumeric extends FloatIsSquantsNumeric with Ordering.FloatOrdering
+  implicit object DoubleIsSquantsNumeric extends DoubleIsSquantsNumeric with Ordering.DoubleOrdering
+
+}

--- a/shared/src/test/scala-2.13/squants/experimental/ScalaVersionSpecificNumericInstances.scala
+++ b/shared/src/test/scala-2.13/squants/experimental/ScalaVersionSpecificNumericInstances.scala
@@ -1,0 +1,10 @@
+package squants.experimental
+
+import squants.experimental.SquantsNumeric.{DoubleIsSquantsNumeric, FloatIsSquantsNumeric}
+
+trait ScalaVersionSpecificNumericInstances {
+
+  implicit object FloatIsSquantsNumeric extends FloatIsSquantsNumeric with Ordering.Float.IeeeOrdering
+  implicit object DoubleIsSquantsNumeric extends DoubleIsSquantsNumeric with Ordering.Double.IeeeOrdering
+
+}

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -65,10 +65,10 @@ class QuantitySpec extends FlatSpec with Matchers with CustomMatchers with TryVa
       def minus(x: T, y: T) = x - y
       def times(x: T, y: T) = x * y
       def negate(x: T) = -x
-      def toInt(x: T) = x.toInt()
-      def toLong(x: T) = x.toLong()
-      def toFloat(x: T) = x.toFloat()
-      def compare(x: T, y: T) = if (x == y) 0 else if (x.toDouble() > y.toDouble()) 1 else -1
+      def toInt(x: T) = x.toInt
+      def toLong(x: T) = x.toLong
+      def toFloat(x: T) = x.toFloat
+      def compare(x: T, y: T) = if (x == y) 0 else if (x.toDouble > y.toDouble) 1 else -1
     }
 
     implicit val stringNumeric = new BaseNumeric[String] {

--- a/shared/src/test/scala/squants/energy/SpecificEnergySpec.scala
+++ b/shared/src/test/scala/squants/energy/SpecificEnergySpec.scala
@@ -94,7 +94,9 @@ class SpecificEnergySpec extends FlatSpec with Matchers {
     val sesRad = List(Rads(100), Rads(10))
     sesRad.sum should be(Rads(110))
 
-    val sesErg = List(ErgsPerGram(100), ErgsPerGram(10))
-    sesErg.sum.in(ErgsPerGram) should be(ErgsPerGram(110))
+    // The Grays(0) value ensures we get the sum in Grays, otherwise unit depends on Scala version
+    // due to changed .sum implementation in 2.13
+    val sesErg = List(Grays(0), ErgsPerGram(100), ErgsPerGram(10))
+    sesErg.sum should be(Grays(0.011))
   }
 }

--- a/shared/src/test/scala/squants/energy/SpecificEnergySpec.scala
+++ b/shared/src/test/scala/squants/energy/SpecificEnergySpec.scala
@@ -95,6 +95,6 @@ class SpecificEnergySpec extends FlatSpec with Matchers {
     sesRad.sum should be(Rads(110))
 
     val sesErg = List(ErgsPerGram(100), ErgsPerGram(10))
-    sesErg.sum should be(Grays(0.011))
+    sesErg.sum.in(ErgsPerGram) should be(ErgsPerGram(110))
   }
 }

--- a/shared/src/test/scala/squants/experimental/SquantsNumeric.scala
+++ b/shared/src/test/scala/squants/experimental/SquantsNumeric.scala
@@ -46,7 +46,7 @@ trait SquantsNumeric[T] extends Ordering[T] {
   implicit def mkSquantsNumericOps(lhs: T): Ops = new Ops(lhs)
 }
 
-object SquantsNumeric {
+object SquantsNumeric extends ScalaVersionSpecificNumericInstances {
 
   trait IntIsSquantsNumeric extends SquantsNumeric[Int] {
     def plus(x: Int, y: Int): Int = x + y
@@ -140,7 +140,5 @@ object SquantsNumeric {
 
   implicit object IntIsSquantsNumeric extends IntIsSquantsNumeric with Ordering.IntOrdering
   implicit object LongIsSquantsNumeric extends LongIsSquantsNumeric with Ordering.LongOrdering
-  implicit object FloatIsSquantsNumeric extends FloatIsSquantsNumeric with Ordering.FloatOrdering
-  implicit object DoubleIsSquantsNumeric extends DoubleIsSquantsNumeric with Ordering.DoubleOrdering
   implicit object BigDecimalIsSquantsNumeric extends BigDecimalIsSquantsNumeric with Ordering.BigDecimalOrdering
 }

--- a/shared/src/test/scala/squants/market/MarketChecks.scala
+++ b/shared/src/test/scala/squants/market/MarketChecks.scala
@@ -55,7 +55,7 @@ object MarketChecks extends Properties("Market") with QuantityChecks {
   }
 
   property("Money / Double + Money / Double = (Money / Double) * 2") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
-    implicit val tolUSD = USD(1e-32)
+    implicit val tolUSD = USD(1e-30)
     val m = if (a > 0) USD(a.toDouble) else USD(1)
     val x = if (b > 0) b.toDouble else 1d
 

--- a/shared/src/test/scala/squants/radio/AreaTimeSpec.scala
+++ b/shared/src/test/scala/squants/radio/AreaTimeSpec.scala
@@ -82,8 +82,10 @@ class AreaTimeSpec extends FlatSpec with Matchers {
   it should "provide Numeric support" in {
     import AreaTimeConversions.AreaTimeNumeric
 
-    val irrs = List(SquareCentimeterSeconds(10), SquareCentimeterSeconds(100))
-    irrs.sum.in(SquareCentimeterSeconds) should be(SquareCentimeterSeconds(110))
+    // The SquareMeterSeconds(0) value ensures we get sum in SquareMeterSeconds, otherwise it depends on Scala version
+    // due to changed .sum implementation in 2.13
+    val irrs = List(SquareMeterSeconds(0), SquareCentimeterSeconds(10), SquareCentimeterSeconds(100))
+    irrs.sum should be(SquareMeterSeconds(0.011))
 
     val smsIrrs =
       List(SquareMeterSeconds(10), SquareMeterSeconds(100))

--- a/shared/src/test/scala/squants/radio/AreaTimeSpec.scala
+++ b/shared/src/test/scala/squants/radio/AreaTimeSpec.scala
@@ -83,7 +83,7 @@ class AreaTimeSpec extends FlatSpec with Matchers {
     import AreaTimeConversions.AreaTimeNumeric
 
     val irrs = List(SquareCentimeterSeconds(10), SquareCentimeterSeconds(100))
-    irrs.sum should be(SquareMeterSeconds(0.011))
+    irrs.sum.in(SquareCentimeterSeconds) should be(SquareCentimeterSeconds(110))
 
     val smsIrrs =
       List(SquareMeterSeconds(10), SquareMeterSeconds(100))


### PR DESCRIPTION
~WIP as it is based on the not yet merged #363 (will rebase asap, for now just ignore the first two commits) and tests didn't compile for native (seems expected), so I let Travis check.~

I found a work-around for https://github.com/scala/bug/issues/11734 (avoiding the indirection via the type aliases in the `squants` package object, see 8cab981). Based on that the PR contains the usual small things to enable the cross build for 2.13, like adapting the build definitions and introducing a small version dependent trait for the tests as `Ordering.FloatOrdering` got split in 2.13.

fixes #344 