### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sum: squants.energy.Power = 35.0 kW
 scala> sum == Kilowatts(35)
 res0: Boolean = true
 
-scala> sum == Megawatts(0.035) // comparisions automatically convert scale
+scala> sum == Megawatts(0.035) // comparisons automatically convert scale
 res1: Boolean = true
 ```
 

--- a/shared/src/main/scala/squants/radio/Dose.scala
+++ b/shared/src/main/scala/squants/radio/Dose.scala
@@ -21,7 +21,7 @@ import squants.time.Time
  * measure absorbed dose which just measures energy deposited into a mass of
  * material while Dose is used to measure equivalent/effective/committed doses
  * which are measures of the damage done to biological tissues.  Since this
- * is an easy and disasterous mistake to make, it is critical that Squants
+ * is an easy and disastrous mistake to make, it is critical that Squants
  * doesn't allow any sort of magic conversions that allow this mistake.
  * @author  Hunter Payne
  *

--- a/shared/src/main/tut/README.md
+++ b/shared/src/main/tut/README.md
@@ -113,7 +113,7 @@ val load1: Power = Kilowatts(12)
 val load2: Power = Megawatts(0.023)
 val sum = load1 + load2
 sum == Kilowatts(35)
-sum == Megawatts(0.035) // comparisions automatically convert scale
+sum == Megawatts(0.035) // comparisons automatically convert scale
 ```
 
 The above sample works because Kilowatts and Megawatts are both units of Power.  Only the scale is


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.