### PR TITLE
run scalatest rewrites for 3.1

### DIFF
--- a/shared/src/test/scala/squants/BinarySystemSpec.scala
+++ b/shared/src/test/scala/squants/BinarySystemSpec.scala
@@ -8,7 +8,8 @@
 
 package squants
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Singleton defining Metric System multipliers
@@ -17,7 +18,7 @@ import org.scalatest.{ FlatSpec, Matchers }
  * @since   0.1
  *
  */
-class BinarySystemSpec extends FlatSpec with Matchers {
+class BinarySystemSpec extends AnyFlatSpec with Matchers {
 
   "The Metric System multipliers" should "convert as expected" in {
     import BinarySystem._

--- a/shared/src/test/scala/squants/DimensionlessSpec.scala
+++ b/shared/src/test/scala/squants/DimensionlessSpec.scala
@@ -8,15 +8,16 @@
 
 package squants
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.time.Hertz
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class DimensionlessSpec extends FlatSpec with Matchers {
+class DimensionlessSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Dimensionless and its Units of Measure"
 

--- a/shared/src/test/scala/squants/MetricSystemSpec.scala
+++ b/shared/src/test/scala/squants/MetricSystemSpec.scala
@@ -8,14 +8,15 @@
 
 package squants
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MetricSystemSpec extends FlatSpec with Matchers {
+class MetricSystemSpec extends AnyFlatSpec with Matchers {
 
   "The Metric System multipliers" should "convert as expected" in {
     import MetricSystem._

--- a/shared/src/test/scala/squants/QuantityRangeSpec.scala
+++ b/shared/src/test/scala/squants/QuantityRangeSpec.scala
@@ -8,15 +8,16 @@
 
 package squants
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.thermal.{ Celsius, Fahrenheit }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class QuantityRangeSpec extends FlatSpec with Matchers {
+class QuantityRangeSpec extends AnyFlatSpec with Matchers {
 
   behavior of "QuantityRange"
 

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -8,7 +8,9 @@
 
 package squants
 
-import org.scalatest.{FlatSpec, Matchers, TryValues}
+import org.scalatest.TryValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.math.BigDecimal.RoundingMode
 import scala.util.{Failure, Try}
@@ -20,7 +22,7 @@ import squants.time.{Hertz, Hours, Minutes}
  * @since   0.1
  *
  */
-class QuantitySpec extends FlatSpec with Matchers with CustomMatchers with TryValues {
+class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with TryValues {
 
   /*
     Create a Quantity with two Units of Measure

--- a/shared/src/test/scala/squants/RatioSpec.scala
+++ b/shared/src/test/scala/squants/RatioSpec.scala
@@ -8,14 +8,15 @@
 
 package squants
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class RatioSpec extends FlatSpec with Matchers {
+class RatioSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Ratio"
 

--- a/shared/src/test/scala/squants/SVectorSpec.scala
+++ b/shared/src/test/scala/squants/SVectorSpec.scala
@@ -8,15 +8,16 @@
 
 package squants
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.space.{Degrees, Kilometers, SquareKilometers, SquareMeters}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.3.0
  *
  */
-class SVectorSpec extends FlatSpec with Matchers {
+class SVectorSpec extends AnyFlatSpec with Matchers {
 
   // TODO Expand tests
 

--- a/shared/src/test/scala/squants/UnitOfMeasureSpec.scala
+++ b/shared/src/test/scala/squants/UnitOfMeasureSpec.scala
@@ -8,15 +8,16 @@
 
 package squants
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.energy.{ Kilowatts, PowerUnit, Watts }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class UnitOfMeasureSpec extends FlatSpec with Matchers {
+class UnitOfMeasureSpec extends AnyFlatSpec with Matchers {
 
   /*
     Create a new UnitOfMeasure for an existing Quantity Type

--- a/shared/src/test/scala/squants/electro/AreaElectricChargeDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/AreaElectricChargeDensitySpec.scala
@@ -1,8 +1,9 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.{Meters, SquareMeters}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   *
@@ -10,7 +11,7 @@ import squants.space.{Meters, SquareMeters}
   * @since 1.4
   *
   */
-class AreaElectricChargeDensitySpec extends FlatSpec with Matchers {
+class AreaElectricChargeDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "AreaElectricChargeDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/CapacitanceSpec.scala
+++ b/shared/src/test/scala/squants/electro/CapacitanceSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.space.Meters
 import squants.{MetricSystem, QuantityParseException}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class CapacitanceSpec extends FlatSpec with Matchers {
+class CapacitanceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Capacitance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ConductivitySpec.scala
+++ b/shared/src/test/scala/squants/electro/ConductivitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.Meters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ConductivitySpec extends FlatSpec with Matchers {
+class ConductivitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Conductivity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricChargeDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricChargeDensitySpec.scala
@@ -1,8 +1,9 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.{CubicMeters, Meters, SquareMeters}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   *
@@ -10,7 +11,7 @@ import squants.space.{CubicMeters, Meters, SquareMeters}
   * @since 1.4
   *
   */
-class ElectricChargeDensitySpec extends FlatSpec with Matchers {
+class ElectricChargeDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricChargeDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricChargeMassRatioSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricChargeMassRatioSpec.scala
@@ -1,8 +1,9 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.mass.Kilograms
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   *
@@ -10,7 +11,7 @@ import squants.mass.Kilograms
   * @since 1.4
   *
   */
-class ElectricChargeMassRatioSpec extends FlatSpec with Matchers {
+class ElectricChargeMassRatioSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricChargeMassRatio and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricChargeSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricChargeSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.{ QuantityParseException, MetricSystem }
 import squants.time.{ Seconds, Time }
 import squants.energy.Joules
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ElectricChargeSpec extends FlatSpec with Matchers {
+class ElectricChargeSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricCharge and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricCurrentDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricCurrentDensitySpec.scala
@@ -1,15 +1,16 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.{Meters, SquareMeters}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author Nicolas Vinuesa
   * @since 1.4
   *
   */
-class ElectricCurrentDensitySpec extends FlatSpec with Matchers {
+class ElectricCurrentDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricCurrentDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricCurrentSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricCurrentSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.{ QuantityParseException, MetricSystem }
 import squants.time.Seconds
 import squants.energy.Watts
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ElectricCurrentSpec extends FlatSpec with Matchers {
+class ElectricCurrentSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricCurrent and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricFieldStrengthSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricFieldStrengthSpec.scala
@@ -1,15 +1,16 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author Nicolas Vinuesa
   * @since 1.4
   *
   */
-class ElectricFieldStrengthSpec extends FlatSpec with Matchers {
+class ElectricFieldStrengthSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricFieldStrength and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricPotentialSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricPotentialSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.{ QuantityParseException, MetricSystem }
 import squants.energy.Watts
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ElectricPotentialSpec extends FlatSpec with Matchers {
+class ElectricPotentialSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricPotential and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricalConductanceSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricalConductanceSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.Meters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ElectricalConductanceSpec extends FlatSpec with Matchers {
+class ElectricalConductanceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricalConductance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ElectricalResistanceSpec.scala
+++ b/shared/src/test/scala/squants/electro/ElectricalResistanceSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.{ QuantityParseException, MetricSystem }
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ElectricalResistanceSpec extends FlatSpec with Matchers {
+class ElectricalResistanceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ElectricalResistance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/InductanceSpec.scala
+++ b/shared/src/test/scala/squants/electro/InductanceSpec.scala
@@ -8,15 +8,16 @@
 
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.{MetricSystem, QuantityParseException}
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class InductanceSpec extends FlatSpec with Matchers {
+class InductanceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Inductance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/LinearElectricChargeDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/LinearElectricChargeDensitySpec.scala
@@ -1,8 +1,9 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   *
@@ -10,7 +11,7 @@ import squants.space.Meters
   * @since 1.4
   *
   */
-class LinearElectricChargeDensitySpec extends FlatSpec with Matchers {
+class LinearElectricChargeDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "LinearElectricChargeDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/MagneticFieldStrengthSpec.scala
+++ b/shared/src/test/scala/squants/electro/MagneticFieldStrengthSpec.scala
@@ -1,15 +1,16 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author Nicolas Vinuesa
   * @since 1.4
   *
   */
-class MagneticFieldStrengthSpec extends FlatSpec with Matchers {
+class MagneticFieldStrengthSpec extends AnyFlatSpec with Matchers {
 
   behavior of "MagneticFieldStrength and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/MagneticFluxDensitySpec.scala
+++ b/shared/src/test/scala/squants/electro/MagneticFluxDensitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.SquareMeters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MagneticFluxDensitySpec extends FlatSpec with Matchers {
+class MagneticFluxDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "MagneticFluxDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/MagneticFluxSpec.scala
+++ b/shared/src/test/scala/squants/electro/MagneticFluxSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.time.Seconds
 import squants.space.SquareMeters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MagneticFluxSpec extends FlatSpec with Matchers {
+class MagneticFluxSpec extends AnyFlatSpec with Matchers {
 
   behavior of "MagneticFlux and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/PermeabilitySpec.scala
+++ b/shared/src/test/scala/squants/electro/PermeabilitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  cquiroz
  * @since   1.4
  *
  */
-class PermeabilitySpec extends FlatSpec with Matchers {
+class PermeabilitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Permeability and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/PermittivitySpec.scala
+++ b/shared/src/test/scala/squants/electro/PermittivitySpec.scala
@@ -1,15 +1,16 @@
 package squants.electro
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author Nicolas Vinuesa
   * @since 1.4
   *
   */
-class PermittivitySpec extends FlatSpec with Matchers {
+class PermittivitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Permittivity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/electro/ResistivitySpec.scala
+++ b/shared/src/test/scala/squants/electro/ResistivitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.electro
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.Meters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ResistivitySpec extends FlatSpec with Matchers {
+class ResistivitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Resistivity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/energy/EnergyDensitySpec.scala
+++ b/shared/src/test/scala/squants/energy/EnergyDensitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.energy
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.CubicMeters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class EnergyDensitySpec extends FlatSpec with Matchers {
+class EnergyDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "EnergyDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/energy/EnergySpec.scala
+++ b/shared/src/test/scala/squants/energy/EnergySpec.scala
@@ -8,7 +8,6 @@
 
 package squants.energy
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.electro.{Coulombs, Volts}
 import squants.mass.{Kilograms, Moles}
 import squants.motion.{MetersPerSecond, NewtonSeconds, Newtons}
@@ -17,13 +16,15 @@ import squants.thermal.{JoulesPerKelvin, Kelvin}
 import squants.time.Hours
 import squants.{MetricSystem, QuantityParseException}
 import squants.radio.{WattsPerSquareMeter, BecquerelsPerSquareMeterSecond}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class EnergySpec extends FlatSpec with Matchers {
+class EnergySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Energy and its Units of Measure"
 

--- a/shared/src/test/scala/squants/energy/MolarEnergySpec.scala
+++ b/shared/src/test/scala/squants/energy/MolarEnergySpec.scala
@@ -1,15 +1,16 @@
 package squants.energy
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.mass.Moles
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author Nicolas Vinuesa
   * @since 1.4
   *
   */
-class MolarEnergySpec extends FlatSpec with Matchers {
+class MolarEnergySpec extends AnyFlatSpec with Matchers {
 
   behavior of "MolarEnergy and its Units of Measure"
 

--- a/shared/src/test/scala/squants/energy/PowerDensitySpec.scala
+++ b/shared/src/test/scala/squants/energy/PowerDensitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.energy
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.CubicMeters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author  Nicolas Vinuesa
   * @since   1.4
   *
   */
-class PowerDensitySpec extends FlatSpec with Matchers {
+class PowerDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "PowerDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/energy/PowerRampSpec.scala
+++ b/shared/src/test/scala/squants/energy/PowerRampSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.energy
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.{ QuantityParseException, MetricSystem }
 import squants.time.Hours
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class PowerRampSpec extends FlatSpec with Matchers {
+class PowerRampSpec extends AnyFlatSpec with Matchers {
 
   behavior of "PowerRamp and its Units of Measure"
 

--- a/shared/src/test/scala/squants/energy/PowerSpec.scala
+++ b/shared/src/test/scala/squants/energy/PowerSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.energy
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.time.Hours
 import squants.{ MetricSystem, QuantityParseException }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class PowerSpec extends FlatSpec with Matchers {
+class PowerSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Power and its Units of Measure"
 

--- a/shared/src/test/scala/squants/energy/SpecificEnergySpec.scala
+++ b/shared/src/test/scala/squants/energy/SpecificEnergySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.energy
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.mass.Kilograms
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class SpecificEnergySpec extends FlatSpec with Matchers {
+class SpecificEnergySpec extends AnyFlatSpec with Matchers {
 
   behavior of "SpecificEnergy and its Units of Measure"
 

--- a/shared/src/test/scala/squants/experimental/ExperimentalSpec.scala
+++ b/shared/src/test/scala/squants/experimental/ExperimentalSpec.scala
@@ -8,11 +8,12 @@
 
 package squants.experimental
 
-import org.scalatest.{Matchers, FlatSpec}
 
 import scala.util.Success
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExperimentalSpec extends FlatSpec with Matchers {
+class ExperimentalSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Experimental Code"
 

--- a/shared/src/test/scala/squants/experimental/formatter/DefaultFormatterSpec.scala
+++ b/shared/src/test/scala/squants/experimental/formatter/DefaultFormatterSpec.scala
@@ -1,6 +1,5 @@
 package squants.experimental.formatter
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.UnitOfMeasure
 import squants.mass.{Kilograms, Mass}
 import squants.mass.MassConversions._
@@ -8,8 +7,10 @@ import squants.space.{Inches, Yards, UsMiles}
 import squants.space.LengthConversions._
 import squants.experimental.unitgroups.UnitGroup
 import squants.experimental.unitgroups.uscustomary.space.UsCustomaryLengths
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DefaultFormatterSpec extends FlatSpec with Matchers {
+class DefaultFormatterSpec extends AnyFlatSpec with Matchers {
 
   val usLengthFormatter = new DefaultFormatter(UsCustomaryLengths)
 

--- a/shared/src/test/scala/squants/experimental/formatter/ImplicitFormatterSpec.scala
+++ b/shared/src/test/scala/squants/experimental/formatter/ImplicitFormatterSpec.scala
@@ -1,6 +1,5 @@
 package squants.experimental.formatter
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.UnitOfMeasure
 import squants.experimental.formatter.implicits._
 import squants.experimental.formatter.syntax._
@@ -11,8 +10,10 @@ import squants.mass.MassConversions._
 import squants.space.LengthConversions._
 import squants.space.{Centimeters, Kilometers, Meters}
 import squants.experimental.unitgroups.UnitGroup
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ImplicitFormatterSpec extends FlatSpec with Matchers {
+class ImplicitFormatterSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ImplicitFormatter"
 

--- a/shared/src/test/scala/squants/experimental/json/QuantitySerializerSpec.scala
+++ b/shared/src/test/scala/squants/experimental/json/QuantitySerializerSpec.scala
@@ -16,8 +16,10 @@ import org.json4s.native.Serialization._
 import squants.market._
 import squants.market.Price
 import squants.mass.{ Mass, Pounds }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
 
-class QuantitySerializerSpec extends FlatSpec with MustMatchers {
+class QuantitySerializerSpec extends AnyFlatSpec with Matchers {
 
   object QuantitySerializerMarshaller {
     implicit val formats = DefaultFormats.withBigDecimal +

--- a/shared/src/test/scala/squants/experimental/unitgroups/UnitGroupSpec.scala
+++ b/shared/src/test/scala/squants/experimental/unitgroups/UnitGroupSpec.scala
@@ -2,11 +2,12 @@ package squants.experimental.unitgroups
 
 import scala.collection.immutable.Set
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.UnitOfMeasure
 import squants.space.{Kilometers, Length, Meters, Nanometers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class UnitGroupSpec extends FlatSpec with Matchers {
+class UnitGroupSpec extends AnyFlatSpec with Matchers {
 
   behavior of "UnitGroup"
 

--- a/shared/src/test/scala/squants/experimental/unitgroups/si/strict/StrictSiSpec.scala
+++ b/shared/src/test/scala/squants/experimental/unitgroups/si/strict/StrictSiSpec.scala
@@ -1,6 +1,5 @@
 package squants.experimental.unitgroups.si.strict
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.energy.Energy
 import squants.mass.Mass
 import squants.space.Length
@@ -9,8 +8,10 @@ import squants.experimental.unitgroups.ImplicitDimensions.energy._
 import squants.experimental.unitgroups.ImplicitDimensions.mass._
 import squants.experimental.unitgroups.UnitGroup
 import squants.experimental.unitgroups.si.strict.implicits._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class StrictSiSpec extends FlatSpec with Matchers {
+class StrictSiSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Strict SI UnitGroups"
 

--- a/shared/src/test/scala/squants/information/DataRateSpec.scala
+++ b/shared/src/test/scala/squants/information/DataRateSpec.scala
@@ -1,14 +1,15 @@
 package squants.information
 
-import org.scalatest.{Matchers, FlatSpec}
 import squants.QuantityParseException
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author Derek Morr
   * @since xxx
   */
-class DataRateSpec extends FlatSpec with Matchers {
+class DataRateSpec extends AnyFlatSpec with Matchers {
 
   behavior of "DataRate and its Units of Measure"
 

--- a/shared/src/test/scala/squants/information/InformationSpec.scala
+++ b/shared/src/test/scala/squants/information/InformationSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.information
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.time.Seconds
 import squants.{BinarySystem, MetricSystem, QuantityParseException}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  Derek Morr
  * @since   0.6.0
  *
  */
-class InformationSpec extends FlatSpec with Matchers {
+class InformationSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Information and its Units of Measure"
 

--- a/shared/src/test/scala/squants/market/CurrencyExchangeRateSpec.scala
+++ b/shared/src/test/scala/squants/market/CurrencyExchangeRateSpec.scala
@@ -8,14 +8,15 @@
 
 package squants.market
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class CurrencyExchangeRateSpec extends FlatSpec with Matchers {
+class CurrencyExchangeRateSpec extends AnyFlatSpec with Matchers {
 
   behavior of "CurrencyExchangeRate"
 

--- a/shared/src/test/scala/squants/market/MoneyContextSpec.scala
+++ b/shared/src/test/scala/squants/market/MoneyContextSpec.scala
@@ -8,14 +8,15 @@
 
 package squants.market
 
-import org.scalatest.{ Matchers, FlatSpec }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MoneyContextSpec extends FlatSpec with Matchers {
+class MoneyContextSpec extends AnyFlatSpec with Matchers {
 
   val defCur = USD
   val rates = List(

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -8,20 +8,21 @@
 
 package squants.market
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.mass.Kilograms
 import squants.space.Meters
 import squants.time.Hours
 import scala.math.BigDecimal.RoundingMode
 import scala.util.{Failure, Success}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MoneySpec extends FlatSpec with Matchers {
+class MoneySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Money and its Units of Measure"
 

--- a/shared/src/test/scala/squants/market/PriceSpec.scala
+++ b/shared/src/test/scala/squants/market/PriceSpec.scala
@@ -8,15 +8,16 @@
 
 package squants.market
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.{ Yards, Meters }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class PriceSpec extends FlatSpec with Matchers {
+class PriceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Price and its Units of Measure"
 

--- a/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
+++ b/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.mass
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.{Acres, Hectares, SquareMeters}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.2.3
  *
  */
-class AreaDensitySpec extends FlatSpec with Matchers {
+class AreaDensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "AreaDensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/mass/ChemicalAmountSpec.scala
+++ b/shared/src/test/scala/squants/mass/ChemicalAmountSpec.scala
@@ -8,15 +8,16 @@
 
 package squants.mass
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ChemicalAmountSpec extends FlatSpec with Matchers {
+class ChemicalAmountSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ChemicalAmount and its Units of Measure"
 

--- a/shared/src/test/scala/squants/mass/DensitySpec.scala
+++ b/shared/src/test/scala/squants/mass/DensitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.mass
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.space.CubicMeters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class DensitySpec extends FlatSpec with Matchers {
+class DensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Density and its Units of Measure"
 

--- a/shared/src/test/scala/squants/mass/MassSpec.scala
+++ b/shared/src/test/scala/squants/mass/MassSpec.scala
@@ -8,18 +8,19 @@
 
 package squants.mass
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.motion._
 import squants.space.{CubicMeters, Meters, SquareMeters}
 import squants.time.Seconds
 import squants.{MetricSystem, QuantityParseException}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MassSpec extends FlatSpec with Matchers {
+class MassSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Mass and its Units of Measure"
 

--- a/shared/src/test/scala/squants/mass/MomentOfInertiaSpec.scala
+++ b/shared/src/test/scala/squants/mass/MomentOfInertiaSpec.scala
@@ -1,16 +1,17 @@
 package squants.mass
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.CustomMatchers
 import squants.motion.{NewtonMeters, RadiansPerSecondSquared}
 import squants.space.{Feet, Meters}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   *
   * @author paxelord
   * @since 1.3
   **/
-class MomentOfInertiaSpec extends FlatSpec with Matchers with CustomMatchers {
+class MomentOfInertiaSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "MomentOfInertia and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/AccelerationSpec.scala
+++ b/shared/src/test/scala/squants/motion/AccelerationSpec.scala
@@ -8,18 +8,19 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.Meters
 import squants.time.Seconds
 import squants.mass.Kilograms
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class AccelerationSpec extends FlatSpec with Matchers {
+class AccelerationSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Acceleration and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/AngularAccelerationSpec.scala
+++ b/shared/src/test/scala/squants/motion/AngularAccelerationSpec.scala
@@ -1,16 +1,17 @@
 package squants.motion
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.{Meters, Radians}
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   *
   * @author paxelord
   * @since 1.3
   */
-class AngularAccelerationSpec extends FlatSpec with Matchers{
+class AngularAccelerationSpec extends AnyFlatSpec with Matchers{
 
   behavior of "AngularAcceleration and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/AngularVelocitySpec.scala
+++ b/shared/src/test/scala/squants/motion/AngularVelocitySpec.scala
@@ -8,17 +8,18 @@
 
 package squants.motion
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.space.{Meters, Radians}
 import squants.QuantityParseException
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class AngularVelocitySpec extends FlatSpec with Matchers {
+class AngularVelocitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "AngularVelocity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/ForceSpec.scala
+++ b/shared/src/test/scala/squants/motion/ForceSpec.scala
@@ -8,19 +8,20 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.mass.Kilograms
 import squants.time.Seconds
 import squants.energy.Joules
 import squants.space.{ SquareMeters, Meters }
 import squants.{ QuantityParseException, CustomMatchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ForceSpec extends FlatSpec with Matchers with CustomMatchers {
+class ForceSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "Force and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/JerkSpec.scala
+++ b/shared/src/test/scala/squants/motion/JerkSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.Meters
 import squants.time.Seconds
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class JerkSpec extends FlatSpec with Matchers {
+class JerkSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Jerk and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/MassFlowSpec.scala
+++ b/shared/src/test/scala/squants/motion/MassFlowSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.mass.Kilograms
 import squants.time.Seconds
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MassFlowSpec extends FlatSpec with Matchers {
+class MassFlowSpec extends AnyFlatSpec with Matchers {
 
   behavior of "MassFlow and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/MomentumSpec.scala
+++ b/shared/src/test/scala/squants/motion/MomentumSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.time.Seconds
 import squants.mass.Kilograms
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class MomentumSpec extends FlatSpec with Matchers {
+class MomentumSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Momentum and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/PressureChangeSpec.scala
+++ b/shared/src/test/scala/squants/motion/PressureChangeSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.motion
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  stevebarham
  * @since   0.5.2
  *
  */
-class PressureChangeSpec extends FlatSpec with Matchers {
+class PressureChangeSpec extends AnyFlatSpec with Matchers {
 
   behavior of "PressureChange and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/PressureSpec.scala
+++ b/shared/src/test/scala/squants/motion/PressureSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.SquareMeters
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class PressureSpec extends FlatSpec with Matchers {
+class PressureSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Pressure and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/TorqueSpec.scala
+++ b/shared/src/test/scala/squants/motion/TorqueSpec.scala
@@ -1,16 +1,17 @@
 package squants.motion
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.{CustomMatchers, QuantityParseException}
 import squants.mass.{KilogramsMetersSquared, PoundsSquareFeet}
 import squants.space.{Feet, Meters}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   *
   * @author paxelord
   * @since 1.2
   */
-class TorqueSpec extends FlatSpec with Matchers with CustomMatchers {
+class TorqueSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "Torque and its Units of Measure"
   

--- a/shared/src/test/scala/squants/motion/VelocitySpec.scala
+++ b/shared/src/test/scala/squants/motion/VelocitySpec.scala
@@ -8,18 +8,19 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.time.Seconds
 import squants.space.Meters
 import squants.mass.Kilograms
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class VelocitySpec extends FlatSpec with Matchers {
+class VelocitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Velocity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/VolumeFlowSpec.scala
+++ b/shared/src/test/scala/squants/motion/VolumeFlowSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.space.CubicMeters
 import squants.time.Seconds
 import squants.{ QuantityParseException, CustomMatchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class VolumeFlowSpec extends FlatSpec with Matchers with CustomMatchers {
+class VolumeFlowSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "VolumeFlow and its Units of Measure"
 

--- a/shared/src/test/scala/squants/motion/YankSpec.scala
+++ b/shared/src/test/scala/squants/motion/YankSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.motion
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.time.Seconds
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class YankSpec extends FlatSpec with Matchers {
+class YankSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Yank and its Units of Measure"
 

--- a/shared/src/test/scala/squants/photo/IlluminanceSpec.scala
+++ b/shared/src/test/scala/squants/photo/IlluminanceSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.photo
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.space.SquareMeters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class IlluminanceSpec extends FlatSpec with Matchers {
+class IlluminanceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Illuminance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/photo/LuminanceSpec.scala
+++ b/shared/src/test/scala/squants/photo/LuminanceSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.photo
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.space.SquareMeters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class LuminanceSpec extends FlatSpec with Matchers {
+class LuminanceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Luminance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/photo/LuminousEnergySpec.scala
+++ b/shared/src/test/scala/squants/photo/LuminousEnergySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.photo
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class LuminousEnergySpec extends FlatSpec with Matchers {
+class LuminousEnergySpec extends AnyFlatSpec with Matchers {
 
   behavior of "LuminousEnergy and its Units of Measure"
 

--- a/shared/src/test/scala/squants/photo/LuminousExposureSpec.scala
+++ b/shared/src/test/scala/squants/photo/LuminousExposureSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.photo
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class LuminousExposureSpec extends FlatSpec with Matchers {
+class LuminousExposureSpec extends AnyFlatSpec with Matchers {
 
   behavior of "LuminousExposure and its Units of Measure"
 

--- a/shared/src/test/scala/squants/photo/LuminousFluxSpec.scala
+++ b/shared/src/test/scala/squants/photo/LuminousFluxSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.photo
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.space.{ SquareMeters, SquaredRadians }
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class LuminousFluxSpec extends FlatSpec with Matchers {
+class LuminousFluxSpec extends AnyFlatSpec with Matchers {
 
   behavior of "LuminousFlux and its Units of Measure"
 

--- a/shared/src/test/scala/squants/photo/LuminousIntensitySpec.scala
+++ b/shared/src/test/scala/squants/photo/LuminousIntensitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.photo
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.space.{ SquareMeters, SquaredRadians }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class LuminousIntensitySpec extends FlatSpec with Matchers {
+class LuminousIntensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "LuminousIntensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/ActivitySpec.scala
+++ b/shared/src/test/scala/squants/radio/ActivitySpec.scala
@@ -8,15 +8,16 @@
 
 package squants.radio
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ActivitySpec extends FlatSpec with Matchers {
+class ActivitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Activity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/AreaTimeSpec.scala
+++ b/shared/src/test/scala/squants/radio/AreaTimeSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.radio
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.space.{ SquareMeters, SquareCentimeters }
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class AreaTimeSpec extends FlatSpec with Matchers {
+class AreaTimeSpec extends AnyFlatSpec with Matchers {
 
   behavior of "AreaTime and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/DoseSpec.scala
+++ b/shared/src/test/scala/squants/radio/DoseSpec.scala
@@ -8,14 +8,15 @@
 
 package squants.radio
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  Hunter Payne
  *
  */
-class DoseSpec extends FlatSpec with Matchers {
+class DoseSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Dose and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/IrradianceSpec.scala
+++ b/shared/src/test/scala/squants/radio/IrradianceSpec.scala
@@ -8,19 +8,20 @@
 
 package squants.radio
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.energy.{Watts, WattHours}
 import squants.space.{SquareCentimeters, SquareMeters}
 import squants.time.Hours
 import squants.CustomMatchers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class IrradianceSpec extends FlatSpec with Matchers with CustomMatchers {
+class IrradianceSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "Irradiance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/ParticleFluxSpec.scala
+++ b/shared/src/test/scala/squants/radio/ParticleFluxSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.radio
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.energy.WattHours
 import squants.time.Hours
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ParticleFluxSpec extends FlatSpec with Matchers {
+class ParticleFluxSpec extends AnyFlatSpec with Matchers {
 
   behavior of "ParticleFlux and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/RadianceSpec.scala
+++ b/shared/src/test/scala/squants/radio/RadianceSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.radio
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.space.SquareMeters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class RadianceSpec extends FlatSpec with Matchers {
+class RadianceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Radiance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/RadiantIntensitySpec.scala
+++ b/shared/src/test/scala/squants/radio/RadiantIntensitySpec.scala
@@ -8,17 +8,18 @@
 
 package squants.radio
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.energy.Watts
 import squants.space.{ Meters, SquareMeters, SquaredRadians }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class RadiantIntensitySpec extends FlatSpec with Matchers {
+class RadiantIntensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "RadiantIntensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/SpectralIntensitySpec.scala
+++ b/shared/src/test/scala/squants/radio/SpectralIntensitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.radio
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class SpectralIntensitySpec extends FlatSpec with Matchers {
+class SpectralIntensitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "SpectralIntensity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/SpectralIrradianceSpec.scala
+++ b/shared/src/test/scala/squants/radio/SpectralIrradianceSpec.scala
@@ -8,15 +8,16 @@
 
 package squants.radio
 
-import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  cquiroz@gemini.edu
  * @since   0.6.1
  *
  */
-class SpectralIrradianceSpec extends FlatSpec with Matchers {
+class SpectralIrradianceSpec extends AnyFlatSpec with Matchers {
 
   behavior of "SpectralIrradiance and its Units of Measure"
 

--- a/shared/src/test/scala/squants/radio/SpectralPowerSpec.scala
+++ b/shared/src/test/scala/squants/radio/SpectralPowerSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.radio
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.energy.Watts
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class SpectralPowerSpec extends FlatSpec with Matchers {
+class SpectralPowerSpec extends AnyFlatSpec with Matchers {
 
   behavior of "SpectralPower and its Units of Measure"
 

--- a/shared/src/test/scala/squants/space/AngleSpec.scala
+++ b/shared/src/test/scala/squants/space/AngleSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.space
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.motion.RadiansPerSecond
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class AngleSpec extends FlatSpec with Matchers {
+class AngleSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Angle and its Units of Measure"
 

--- a/shared/src/test/scala/squants/space/AreaSpec.scala
+++ b/shared/src/test/scala/squants/space/AreaSpec.scala
@@ -8,20 +8,21 @@
 
 package squants.space
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.mass.{ Kilograms, KilogramsPerSquareMeter }
 import squants.motion.{ Newtons, Pascals }
 import squants.photo.{ Candelas, CandelasPerSquareMeter, Lumens, Lux }
 import squants.time.Seconds
 import squants.radio.SquareMeterSeconds
 import squants.{ MetricSystem, QuantityParseException }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class AreaSpec extends FlatSpec with Matchers {
+class AreaSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Area and its Units of Measure"
 

--- a/shared/src/test/scala/squants/space/LengthSpec.scala
+++ b/shared/src/test/scala/squants/space/LengthSpec.scala
@@ -8,19 +8,20 @@
 
 package squants.space
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.electro.{ OhmMeters, Ohms, Siemens, SiemensPerMeter }
 import squants.energy.Joules
 import squants.motion.{ MetersPerSecond, Newtons }
 import squants.time.Seconds
 import squants.{ MetricSystem, QuantityParseException }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class LengthSpec extends FlatSpec with Matchers {
+class LengthSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Length and its Units of Measure"
 

--- a/shared/src/test/scala/squants/space/SolidAngleSpec.scala
+++ b/shared/src/test/scala/squants/space/SolidAngleSpec.scala
@@ -8,16 +8,17 @@
 
 package squants.space
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.photo.{ Candelas, Lumens }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class SolidAngleSpec extends FlatSpec with Matchers {
+class SolidAngleSpec extends AnyFlatSpec with Matchers {
 
   behavior of "SolidAngle and its Units of Measure"
 

--- a/shared/src/test/scala/squants/space/VolumeSpec.scala
+++ b/shared/src/test/scala/squants/space/VolumeSpec.scala
@@ -8,19 +8,20 @@
 
 package squants.space
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
 import squants.energy.{ Joules, JoulesPerCubicMeter }
 import squants.mass.{ Kilograms, KilogramsPerCubicMeter }
 import squants.motion.CubicMetersPerSecond
 import squants.time.Seconds
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class VolumeSpec extends FlatSpec with Matchers {
+class VolumeSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Volume and its Units of Measure"
 

--- a/shared/src/test/scala/squants/thermal/TemperatureSpec.scala
+++ b/shared/src/test/scala/squants/thermal/TemperatureSpec.scala
@@ -8,18 +8,20 @@
 
 package squants.thermal
 
-import org.scalatest.{ FlatSpec, Matchers, TryValues }
+import org.scalatest.TryValues
 import org.scalatest.prop.TableDrivenPropertyChecks
 import squants.energy.Joules
 import squants.mass.Kilograms
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class TemperatureSpec extends FlatSpec
+class TemperatureSpec extends AnyFlatSpec
   with Matchers with TableDrivenPropertyChecks with TryValues {
 
   behavior of "Temperature and its Units of Measure"

--- a/shared/src/test/scala/squants/thermal/ThermalCapacitySpec.scala
+++ b/shared/src/test/scala/squants/thermal/ThermalCapacitySpec.scala
@@ -8,16 +8,17 @@
 
 package squants.thermal
 
-import org.scalatest.{ Matchers, FlatSpec }
 import squants.energy.Joules
 import squants.QuantityParseException
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class ThermalCapacitySpec extends FlatSpec with Matchers {
+class ThermalCapacitySpec extends AnyFlatSpec with Matchers {
 
   behavior of "ThermalCapacity and its Units of Measure"
 

--- a/shared/src/test/scala/squants/time/FrequencySpec.scala
+++ b/shared/src/test/scala/squants/time/FrequencySpec.scala
@@ -8,7 +8,6 @@
 
 package squants.time
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.electro.{ Amperes, Coulombs, Volts, Webers }
 import squants.energy.{ WattHours, Watts, WattsPerHour }
 import squants.information.{ Bytes, BytesPerSecond }
@@ -17,13 +16,15 @@ import squants.motion._
 import squants.photo.{ LumenSeconds, Lumens, Lux, LuxSeconds }
 import squants.space.{ CubicMeters, Meters, Radians }
 import squants.{ Dimension, Each, MetricSystem, QuantityParseException }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class FrequencySpec extends FlatSpec with Matchers {
+class FrequencySpec extends AnyFlatSpec with Matchers {
 
   behavior of "Frequency and its Units of Measure"
 

--- a/shared/src/test/scala/squants/time/SecondTimeDerivativeSpec.scala
+++ b/shared/src/test/scala/squants/time/SecondTimeDerivativeSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.time
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.CustomMatchers
 import squants.motion.MetersPerSecondSquared
 import squants.space.Meters
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.5.0
  *
  */
-class SecondTimeDerivativeSpec extends FlatSpec with Matchers with CustomMatchers {
+class SecondTimeDerivativeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "Second Time Derivatives and Integrals as implemented in Distance and Acceleration"
 

--- a/shared/src/test/scala/squants/time/TimeDerivativeSpec.scala
+++ b/shared/src/test/scala/squants/time/TimeDerivativeSpec.scala
@@ -8,17 +8,18 @@
 
 package squants.time
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.CustomMatchers
 import squants.motion.UsMilesPerHour
 import squants.space.UsMiles
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class TimeDerivativeSpec extends FlatSpec with Matchers with CustomMatchers {
+class TimeDerivativeSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "Time Derivatives and Integrals as implemented in Distance and Velocity"
 

--- a/shared/src/test/scala/squants/time/TimeSpec.scala
+++ b/shared/src/test/scala/squants/time/TimeSpec.scala
@@ -8,20 +8,21 @@
 
 package squants.time
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.{ Dimension, QuantityParseException }
 import squants.motion.{ MetersPerSecond, MetersPerSecondCubed, MetersPerSecondSquared }
 import squants.space.{ Meters, SquareMeters }
 import squants.radio.SquareMeterSeconds
 
 import scala.concurrent.duration.{ DAYS, Duration, HOURS, MICROSECONDS, MILLISECONDS, MINUTES, NANOSECONDS, SECONDS }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.1
  *
  */
-class TimeSpec extends FlatSpec with Matchers {
+class TimeSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Time and its Units of Measure"
 

--- a/shared/src/test/scala/squants/time/TimeSquaredSpec.scala
+++ b/shared/src/test/scala/squants/time/TimeSquaredSpec.scala
@@ -1,14 +1,15 @@
 package squants.time
 
-import org.scalatest.{ FlatSpec, Matchers }
 import squants.CustomMatchers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author  garyKeorkunian
  * @since   0.5.1
  *
  */
-class TimeSquaredSpec extends FlatSpec with Matchers with CustomMatchers {
+class TimeSquaredSpec extends AnyFlatSpec with Matchers with CustomMatchers {
 
   behavior of "Time Squared as an intermediate operand in time derivative calculations"
 


### PR DESCRIPTION
Should unblock #401

This removes uses of deprecated traits and uses the new traits. These are only name changes.