### PR TITLE
Try to publish to scala.js 0.6 correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
           key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}-${{ hashFiles('project/*.scala') }}
           restore-keys: ${{ runner.os }}-sbt-
       - name: Publish
-        run: |
-          csbt ci-release
-          SCALAJS_VERSION=0.6.33 csbt ci-release
+        run: csbt ci-release
+      - name: Publish 0.6
+        run: SCALAJS_VERSION=0.6.33 csbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ tmp/
 .project
 .scala_dependencies
 .settings/
+project/metals.sbt
 
 # Mac OS X
 ._*

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,6 @@ lazy val squants =
     parallelExecution in Test := false,
     excludeFilter in Test := "*Serializer.scala" || "*SerializerSpec.scala",
     scalacOptions in Tut --= Seq("-Ywarn-unused-import", "-Ywarn-unused:imports"),
-    // sources in (Compile, test) := List() // This is a pity but we can't reliable compile on 1.0.0-M8
   )
   .jsSettings(Tests.defaultSettings: _*)
   .nativeSettings(
@@ -60,9 +59,15 @@ lazy val squants =
 
 lazy val root = project.in(file("."))
   .settings(defaultSettings: _*)
+  .settings(noPublishSettings)
   .settings(
     name := "squants",
-    publish := {},
-    publishLocal := {}
   )
   .aggregate(squants.jvm, squants.js, squants.native)
+
+lazy val noPublishSettings = Seq(
+  publish := {},
+  publishLocal := {},
+  publishArtifact := false,
+  skip in publish := true
+)


### PR DESCRIPTION
The last release didn't publist to scala.js 0.6 correctly. This may fix but I'll have to test it a few times to be sure