### PR TITLE
Added Turkish lira to supported currencies

### DIFF
--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -471,6 +471,7 @@ object ETH extends Currency("ETH", "Ether", "\u039E", 15)
 object LTC extends Currency("LTC", "Litecoin", "\u0141", 15)
 object ZAR extends Currency("ZAR", "South African Rand", "R", 2)
 object NAD extends Currency("NAD", "Namibian Dollar", "N$", 2)
+object TRY extends Currency("TRY", "Turkish lira", "₺", 2)
 
 /**
  * Support for Money DSL
@@ -512,6 +513,7 @@ object MoneyConversions {
     def litecoin = LTC
     def ZAR = Money(n, squants.market.ZAR)
     def NAD = Money(n, squants.market.NAD)
+    def TRY = Money(n, squants.market.TRY)
   }
 
   class MoneyNumeric()(implicit mc: MoneyContext) extends Numeric[Money] {

--- a/shared/src/main/scala/squants/market/package.scala
+++ b/shared/src/main/scala/squants/market/package.scala
@@ -61,7 +61,7 @@ package object market {
     EUR, GBP, HKD, INR, JPY,
     KRW, MXN, MYR, NOK, NZD,
     RUB, SEK, XAG, XAU, BTC,
-    ETH, LTC, ZAR, NAD)
+    ETH, LTC, ZAR, NAD, TRY)
 
   lazy val defaultMoneyContext = MoneyContext(USD, defaultCurrencySet, Nil)
 

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -484,6 +484,7 @@ class MoneySpec extends AnyFlatSpec with Matchers {
     d.litecoin should be(LTC(d))
     d.ZAR should be(ZAR(d))
     d.NAD should be(NAD(d))
+    d.TRY should be(TRY(d))
   }
 
   it should "provide Numeric support within a MoneyContext with no Exchange Rates" in {


### PR DESCRIPTION
Added **Turkish lira** (Code 949 ISO-4217) as a supported currency.

ISO-4217 | -
-- | --
Code | TRY
Symbol | ₺
Number | 949
Exponent | 2



**More info**: https://www.iso.org/iso-4217-currency-codes.html
