### PR TITLE
Make `hashCode` of quantities stable across runs

### DIFF
--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -84,6 +84,14 @@ trait Dimension[A <: Quantity[A]] {
   }
 
   implicit val dimensionImplicit: Dimension[A] = this
+
+  override def equals(that: Any): Boolean = that match {
+    case dimension: Dimension[_] => dimension.getClass.getName == this.getClass.getName
+    case _ => false
+  }
+
+  override def hashCode(): Int = getClass.getName.hashCode
+
 }
 
 case class QuantityParseException(message: String, expression: String) extends Exception(s"$message:$expression")

--- a/shared/src/test/scala/squants/DimensionSpec.scala
+++ b/shared/src/test/scala/squants/DimensionSpec.scala
@@ -1,0 +1,19 @@
+/*                                                                      *\
+** Squants                                                              **
+**                                                                      **
+** Scala Quantities and Units of Measure Library and DSL                **
+** (c) 2013-2015, Gary Keorkunian                                       **
+**                                                                      **
+\*                                                                      */
+
+package squants
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DimensionSpec extends AnyFlatSpec with Matchers {
+
+  "Dimensions" should "have a stable hashCode" in {
+    space.Length.hashCode.toHexString should be("29d67c0b")
+  }
+}


### PR DESCRIPTION
Having a stable `hashCode` can be useful for some things related to serialization.

This is why case objects do have a stable `hashCode`.

Here, I propose to derive the `hashCode` of `Dimension` objects from their fully qualified class names.
