### PR TITLE
Enable MdocPlugin on a separate docs module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val squants =
   .in(file("."))
   .settings(defaultSettings: _*)
   .jvmConfigure(
-    _.enablePlugins(MdocPlugin, SbtOsgi)
+    _.enablePlugins(SbtOsgi)
   )
   .jvmSettings(
     osgiSettings,
@@ -48,6 +48,15 @@ lazy val squants =
     crossScalaVersions := Versions.ScalaCross.filterNot(_.startsWith("3")),
     Compile / doc / sources := List(), // Can't build docs in native
   )
+
+lazy val docs =
+  project.in(file("squants-docs"))
+    .dependsOn(squants.jvm)
+    .enablePlugins(MdocPlugin)
+    .settings(
+      scalaVersion := "2.13.5",
+      mdocOut := (ThisBuild / baseDirectory).value
+    )
 
 lazy val root = project.in(file("."))
   .settings(defaultSettings: _*)


### PR DESCRIPTION
The goal here is to remove the `mdoc` dependency from the core `squants` artifacts.

I noticed that running mdoc was failing on the current `README.md` file. Unfortunately, this PR does not fix that as well. It seems that the README refers to non-existing APIs.