### PR TITLE
Exclude mdoc dependency for downstream apps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val docs =
     .settings(
       scalaVersion := "2.13.6",
       mdocOut := (ThisBuild / baseDirectory).value
-      mdocAutoDependency := false
+      mdocAutoDependency := false,
     )
 
 lazy val root = project.in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val docs =
     .enablePlugins(MdocPlugin)
     .settings(
       scalaVersion := "2.13.6",
-      mdocOut := (ThisBuild / baseDirectory).value
+      mdocOut := (ThisBuild / baseDirectory).value,
       mdocAutoDependency := false,
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,8 @@ lazy val docs =
     .enablePlugins(MdocPlugin)
     .settings(
       scalaVersion := "2.13.5",
-      mdocOut := (ThisBuild / baseDirectory).value
+      mdocOut := (ThisBuild / baseDirectory).value,
+      mdocAutoDependency := false
     )
 
 lazy val root = project.in(file("."))


### PR DESCRIPTION
mdocAutoDependency: exclude mdoc as a library dependency as it is not necessary for downstream apps (unless I am mistaken of course ;-) ).