### PR TITLE
481: Add hashCode and equals for `Currency` class

### DIFF
--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -433,6 +433,24 @@ abstract class Currency(val code: String, val name: String, val symbol: String, 
   protected def converterTo: Double ⇒ Double = ???
   def /(that: Money): CurrencyExchangeRate = that toThe Money(1, this)
   override def toString: String = code
+
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[Currency]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Currency =>
+      (that canEqual this) &&
+        code == that.code &&
+        name == that.name &&
+        symbol == that.symbol &&
+        formatDecimals == that.formatDecimals
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(code, name, symbol, formatDecimals)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
 }
 
 object Currency {


### PR DESCRIPTION
Fixes #481 by adding a hashcode/equals for `Currency` class. It has been generated by intellij idea