### PR TITLE
feat: Add Density units (k|m|µ|n)g per (k|m|µ|n)l

### DIFF
--- a/shared/src/main/scala/squants/mass/Density.scala
+++ b/shared/src/main/scala/squants/mass/Density.scala
@@ -9,6 +9,9 @@
 package squants.mass
 
 import squants._
+import squants.space.{CubicMeters, Litres, Microlitres, Millilitres, Nanolitres}
+
+import scala.util.Try
 
 /**
  * @author  garyKeorkunian
@@ -19,36 +22,265 @@ import squants._
 final class Density private (val value: Double, val unit: DensityUnit)
     extends Quantity[Density] {
 
-  def dimension = Density
+  def dimension: Dimension[Density] = Density
 
-  def *(that: Volume): Mass = Kilograms(this.value * that.toCubicMeters)
+  def *(that: Volume): Mass = Kilograms(this.toKilogramsPerCubicMeter * that.toCubicMeters)
 
-  def toKilogramsPerCubicMeter = to(KilogramsPerCubicMeter)
+  def toKilogramsPerCubicMeter: Double = to(KilogramsPerCubicMeter)
+  def toKilogramsPerLitre: Double = to(KilogramsPerLitre)
+  def toGramsPerLitre: Double = to(GramsPerLitre)
+  def toMilligramsPerLitre: Double = to(MilligramsPerLitre)
+  def toMicrogramsPerLitre: Double = to(MicrogramsPerLitre)
+  def toNanogramsPerLitre: Double = to(NanogramsPerLitre)
+  def toKilogramsPerMillilitre: Double = to(KilogramsPerMillilitre)
+  def toGramsPerMillilitre: Double = to(GramsPerMillilitre)
+  def toMilligramsPerMillilitre: Double = to(MilligramsPerMillilitre)
+  def toMicrogramsPerMillilitre: Double = to(MicrogramsPerMillilitre)
+  def toNanogramsPerMillilitre: Double = to(NanogramsPerMillilitre)
+  def toKilogramsPerMicrolitre: Double = to(KilogramsPerMicrolitre)
+  def toGramsPerMicrolitre: Double = to(GramsPerMicrolitre)
+  def toMilligramsPerMicrolitre: Double = to(MilligramsPerMicrolitre)
+  def toMicrogramsPerMicrolitre: Double = to(MicrogramsPerMicrolitre)
+  def toNanogramsPerMicrolitre: Double = to(NanogramsPerMicrolitre)
+  def toKilogramsPerNanolitre: Double = to(KilogramsPerNanolitre)
+  def toGramsPerNanolitre: Double = to(GramsPerNanolitre)
+  def toMilligramsPerNanolitre: Double = to(MilligramsPerNanolitre)
+  def toMicrogramsPerNanolitre: Double = to(MicrogramsPerNanolitre)
+  def toNanogramsPerNanolitre: Double = to(NanogramsPerNanolitre)
 }
 
 object Density extends Dimension[Density] {
   private[mass] def apply[A](n: A, unit: DensityUnit)(implicit num: Numeric[A]) = new Density(num.toDouble(n), unit)
   def apply(m: Mass, v: Volume): Density = KilogramsPerCubicMeter(m.toKilograms / v.toCubicMeters)
-  def apply(value: Any) = parse(value)
+  def apply(value: Any): Try[Density] = parse(value)
   def name = "Density"
-  def primaryUnit = KilogramsPerCubicMeter
-  def siUnit = KilogramsPerCubicMeter
-  def units = Set(KilogramsPerCubicMeter)
+  def primaryUnit: UnitOfMeasure[Density] with PrimaryUnit = KilogramsPerCubicMeter
+  def siUnit: UnitOfMeasure[Density] with SiUnit = KilogramsPerCubicMeter
+  def units = Set(KilogramsPerCubicMeter,
+    KilogramsPerLitre, GramsPerLitre, MilligramsPerLitre, MicrogramsPerLitre, NanogramsPerLitre,
+    KilogramsPerMillilitre, GramsPerMillilitre, MilligramsPerMillilitre, MicrogramsPerMillilitre, NanogramsPerMillilitre,
+    KilogramsPerMicrolitre, GramsPerMicrolitre, MilligramsPerMicrolitre, MicrogramsPerMicrolitre, NanogramsPerMicrolitre,
+    KilogramsPerNanolitre, GramsPerNanolitre, MilligramsPerNanolitre, MicrogramsPerNanolitre, NanogramsPerNanolitre
+  )
 }
 
 trait DensityUnit extends UnitOfMeasure[Density] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Density(n, this)
+  def apply[A](n: A)(implicit num: Numeric[A]): Density = Density(n, this)
 }
 
 object KilogramsPerCubicMeter extends DensityUnit with PrimaryUnit with SiUnit {
   val symbol = "kg/m³"
 }
 
+object KilogramsPerLitre extends DensityUnit {
+  val symbol = "kg/L"
+  val conversionFactor: Double = CubicMeters.conversionFactor / Litres.conversionFactor
+}
+
+object GramsPerLitre extends DensityUnit {
+  val symbol = "g/L"
+  val conversionFactor: Double = (Grams.conversionFactor / Kilograms.conversionFactor) /
+    (Litres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MilligramsPerLitre extends DensityUnit {
+  val symbol = "mg/L"
+  val conversionFactor: Double = (Milligrams.conversionFactor / Kilograms.conversionFactor) /
+    (Litres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MicrogramsPerLitre extends DensityUnit {
+  val symbol = "µg/L"
+  val conversionFactor: Double = (Micrograms.conversionFactor / Kilograms.conversionFactor) /
+    (Litres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object NanogramsPerLitre extends DensityUnit {
+  val symbol = "ng/L"
+  val conversionFactor: Double = (Nanograms.conversionFactor / Kilograms.conversionFactor) /
+    (Litres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object KilogramsPerMillilitre extends DensityUnit {
+  val symbol = "kg/ml"
+  val conversionFactor: Double = CubicMeters.conversionFactor / Millilitres.conversionFactor
+}
+
+object GramsPerMillilitre extends DensityUnit {
+  val symbol = "g/ml"
+  val conversionFactor: Double = (Grams.conversionFactor / Kilograms.conversionFactor) /
+    (Millilitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MilligramsPerMillilitre extends DensityUnit {
+  val symbol = "mg/ml"
+  val conversionFactor: Double = (Milligrams.conversionFactor / Kilograms.conversionFactor) /
+    (Millilitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MicrogramsPerMillilitre extends DensityUnit {
+  val symbol = "µg/ml"
+  val conversionFactor: Double = (Micrograms.conversionFactor / Kilograms.conversionFactor) /
+    (Millilitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object NanogramsPerMillilitre extends DensityUnit {
+  val symbol = "ng/ml"
+  val conversionFactor: Double = (Nanograms.conversionFactor / Kilograms.conversionFactor) /
+    (Millilitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object KilogramsPerMicrolitre extends DensityUnit {
+  val symbol = "kg/µl"
+  val conversionFactor: Double = CubicMeters.conversionFactor / Microlitres.conversionFactor
+}
+
+object GramsPerMicrolitre extends DensityUnit {
+  val symbol = "g/µl"
+  val conversionFactor: Double = (Grams.conversionFactor / Kilograms.conversionFactor) /
+    (Microlitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MilligramsPerMicrolitre extends DensityUnit {
+  val symbol = "mg/µl"
+  val conversionFactor: Double = (Milligrams.conversionFactor / Kilograms.conversionFactor) /
+    (Microlitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MicrogramsPerMicrolitre extends DensityUnit {
+  val symbol = "µg/µl"
+  val conversionFactor: Double = (Micrograms.conversionFactor / Kilograms.conversionFactor) /
+    (Microlitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object NanogramsPerMicrolitre extends DensityUnit {
+  val symbol = "ng/µl"
+  val conversionFactor: Double = (Nanograms.conversionFactor / Kilograms.conversionFactor) /
+    (Microlitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object KilogramsPerNanolitre extends DensityUnit {
+  val symbol = "kg/nl"
+  val conversionFactor: Double = CubicMeters.conversionFactor / Nanolitres.conversionFactor
+}
+
+object GramsPerNanolitre extends DensityUnit {
+  val symbol = "g/nl"
+  val conversionFactor: Double = (Grams.conversionFactor / Kilograms.conversionFactor) /
+    (Nanolitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MilligramsPerNanolitre extends DensityUnit {
+  val symbol = "mg/nl"
+  val conversionFactor: Double = (Milligrams.conversionFactor / Kilograms.conversionFactor) /
+    (Nanolitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object MicrogramsPerNanolitre extends DensityUnit {
+  val symbol = "µg/nl"
+  val conversionFactor: Double = (Micrograms.conversionFactor / Kilograms.conversionFactor) /
+    (Nanolitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
+object NanogramsPerNanolitre extends DensityUnit {
+  val symbol = "ng/nl"
+  val conversionFactor: Double = (Nanograms.conversionFactor / Kilograms.conversionFactor) /
+    (Nanolitres.conversionFactor / CubicMeters.conversionFactor)
+}
+
 object DensityConversions {
-  lazy val kilogramPerCubicMeter = KilogramsPerCubicMeter(1)
+  lazy val kilogramPerCubicMeter: Density = KilogramsPerCubicMeter(1)
+
+  lazy val kilogramsPerLitre: Density = KilogramsPerLitre(1)
+  lazy val kilogramsPerLiter: Density = KilogramsPerLitre(1)
+  lazy val gramsPerLitre: Density = GramsPerLitre(1)
+  lazy val gramsPerLiter: Density = GramsPerLitre(1)
+  lazy val milligramsPerLitre: Density = MilligramsPerLitre(1)
+  lazy val milligramsPerLiter: Density = MilligramsPerLitre(1)
+  lazy val microgramsPerLitre: Density = MicrogramsPerLitre(1)
+  lazy val microgramsPerLiter: Density = MicrogramsPerLitre(1)
+  lazy val nanogramsPerLitre: Density = NanogramsPerLitre(1)
+  lazy val nanogramsPerLiter: Density = NanogramsPerLitre(1)
+
+  lazy val kilogramsPerMillilitre: Density = KilogramsPerMillilitre(1)
+  lazy val kilogramsPerMilliliter: Density = KilogramsPerMillilitre(1)
+  lazy val gramsPerMillilitre: Density = GramsPerMillilitre(1)
+  lazy val gramsPerMilliliter: Density = GramsPerMillilitre(1)
+  lazy val milligramsPerMillilitre: Density = MilligramsPerMillilitre(1)
+  lazy val milligramsPerMilliliter: Density = MilligramsPerMillilitre(1)
+  lazy val microgramsPerMillilitre: Density = MicrogramsPerMillilitre(1)
+  lazy val microgramsPerMilliliter: Density = MicrogramsPerMillilitre(1)
+  lazy val nanogramsPerMillilitre: Density = NanogramsPerMillilitre(1)
+  lazy val nanogramsPerMilliliter: Density = NanogramsPerMillilitre(1)
+
+  lazy val kilogramsPerMicrolitre: Density = KilogramsPerMicrolitre(1)
+  lazy val kilogramsPerMicroliter: Density = KilogramsPerMicrolitre(1)
+  lazy val gramsPerMicrolitre: Density = GramsPerMicrolitre(1)
+  lazy val gramsPerMicroliter: Density = GramsPerMicrolitre(1)
+  lazy val milligramsPerMicrolitre: Density = MilligramsPerMicrolitre(1)
+  lazy val milligramsPerMicroliter: Density = MilligramsPerMicrolitre(1)
+  lazy val microgramsPerMicrolitre: Density = MicrogramsPerMicrolitre(1)
+  lazy val microgramsPerMicroliter: Density = MicrogramsPerMicrolitre(1)
+  lazy val nanogramsPerMicrolitre: Density = NanogramsPerMicrolitre(1)
+  lazy val nanogramsPerMicroliter: Density = NanogramsPerMicrolitre(1)
+
+  lazy val kilogramsPerNanolitre: Density = KilogramsPerNanolitre(1)
+  lazy val kilogramsPerNanoliter: Density = KilogramsPerNanolitre(1)
+  lazy val gramsPerNanolitre: Density = GramsPerNanolitre(1)
+  lazy val gramsPerNanoliter: Density = GramsPerNanolitre(1)
+  lazy val milligramsPerNanolitre: Density = MilligramsPerNanolitre(1)
+  lazy val milligramsPerNanoliter: Density = MilligramsPerNanolitre(1)
+  lazy val microgramsPerNanolitre: Density = MicrogramsPerNanolitre(1)
+  lazy val microgramsPerNanoliter: Density = MicrogramsPerNanolitre(1)
+  lazy val nanogramsPerNanolitre: Density = NanogramsPerNanolitre(1)
+  lazy val nanogramsPerNanoliter: Density = NanogramsPerNanolitre(1)
 
   implicit class AreaDensityConversions[A](n: A)(implicit num: Numeric[A]) {
-    def kilogramsPerCubicMeter = KilogramsPerCubicMeter(n)
+    def kilogramsPerCubicMeter: Density = KilogramsPerCubicMeter(n)
+
+    def kilogramsPerLitre: Density = KilogramsPerLitre(n)
+    def kilogramsPerLiter: Density = KilogramsPerLitre(n)
+    def gramsPerLitre: Density = GramsPerLitre(n)
+    def gramsPerLiter: Density = GramsPerLitre(n)
+    def milligramsPerLitre: Density = MilligramsPerLitre(n)
+    def milligramsPerLiter: Density = MilligramsPerLitre(n)
+    def microgramsPerLitre: Density = MicrogramsPerLitre(n)
+    def microgramsPerLiter: Density = MicrogramsPerLitre(n)
+    def nanogramsPerLitre: Density = NanogramsPerLitre(n)
+    def nanogramsPerLiter: Density = NanogramsPerLitre(n)
+
+    def kilogramsPerMillilitre: Density = KilogramsPerMillilitre(n)
+    def kilogramsPerMilliliter: Density = KilogramsPerMillilitre(n)
+    def gramsPerMillilitre: Density = GramsPerMillilitre(n)
+    def gramsPerMilliliter: Density = GramsPerMillilitre(n)
+    def milligramsPerMillilitre: Density = MilligramsPerMillilitre(n)
+    def milligramsPerMilliliter: Density = MilligramsPerMillilitre(n)
+    def microgramsPerMillilitre: Density = MicrogramsPerMillilitre(n)
+    def microgramsPerMilliliter: Density = MicrogramsPerMillilitre(n)
+    def nanogramsPerMillilitre: Density = NanogramsPerMillilitre(n)
+    def nanogramsPerMilliliter: Density = NanogramsPerMillilitre(n)
+
+    def kilogramsPerMicrolitre: Density = KilogramsPerMicrolitre(n)
+    def kilogramsPerMicroliter: Density = KilogramsPerMicrolitre(n)
+    def gramsPerMicrolitre: Density = GramsPerMicrolitre(n)
+    def gramsPerMicroliter: Density = GramsPerMicrolitre(n)
+    def milligramsPerMicrolitre: Density = MilligramsPerMicrolitre(n)
+    def milligramsPerMicroliter: Density = MilligramsPerMicrolitre(n)
+    def microgramsPerMicrolitre: Density = MicrogramsPerMicrolitre(n)
+    def microgramsPerMicroliter: Density = MicrogramsPerMicrolitre(n)
+    def nanogramsPerMicrolitre: Density = NanogramsPerMicrolitre(n)
+    def nanogramsPerMicroliter: Density = NanogramsPerMicrolitre(n)
+
+    def kilogramsPerNanolitre: Density = KilogramsPerNanolitre(n)
+    def kilogramsPerNanoliter: Density = KilogramsPerNanolitre(n)
+    def gramsPerNanolitre: Density = GramsPerNanolitre(n)
+    def gramsPerNanoliter: Density = GramsPerNanolitre(n)
+    def milligramsPerNanolitre: Density = MilligramsPerNanolitre(n)
+    def milligramsPerNanoliter: Density = MilligramsPerNanolitre(n)
+    def microgramsPerNanolitre: Density = MicrogramsPerNanolitre(n)
+    def microgramsPerNanoliter: Density = MicrogramsPerNanolitre(n)
+    def nanogramsPerNanolitre: Density = NanogramsPerNanolitre(n)
+    def nanogramsPerNanoliter: Density = NanogramsPerNanolitre(n)
   }
 
   implicit object DensityNumeric extends AbstractQuantityNumeric[Density](KilogramsPerCubicMeter)

--- a/shared/src/test/scala/squants/mass/DensitySpec.scala
+++ b/shared/src/test/scala/squants/mass/DensitySpec.scala
@@ -9,7 +9,7 @@
 package squants.mass
 
 import squants.QuantityParseException
-import squants.space.CubicMeters
+import squants.space.{CubicMeters, Litres, Millilitres}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -24,10 +24,31 @@ class DensitySpec extends AnyFlatSpec with Matchers {
 
   it should "create values using UOM factories" in {
     KilogramsPerCubicMeter(1).toKilogramsPerCubicMeter should be(1)
+    KilogramsPerLitre(1).toKilogramsPerLitre should be(1)
+    GramsPerLitre(1).toGramsPerLitre should be(1)
+    MilligramsPerLitre(1).toMilligramsPerLitre should be(1)
+    MicrogramsPerLitre(1).toMicrogramsPerLitre should be(1)
+    NanogramsPerLitre(1).toNanogramsPerLitre should be(1)
+    KilogramsPerMillilitre(1).toKilogramsPerMillilitre should be(1)
+    GramsPerMillilitre(1).toGramsPerMillilitre should be(1)
+    MilligramsPerMillilitre(1).toMilligramsPerMillilitre should be(1)
+    MicrogramsPerMillilitre(1).toMicrogramsPerMillilitre should be(1)
+    NanogramsPerMillilitre(1).toNanogramsPerMillilitre should be(1)
+    KilogramsPerMicrolitre(1).toKilogramsPerMicrolitre should be(1)
+    GramsPerMicrolitre(1).toGramsPerMicrolitre should be(1)
+    MilligramsPerMicrolitre(1).toMilligramsPerMicrolitre should be(1)
+    MicrogramsPerMicrolitre(1).toMicrogramsPerMicrolitre should be(1)
+    NanogramsPerMicrolitre(1).toNanogramsPerMicrolitre should be(1)
+    KilogramsPerNanolitre(1).toKilogramsPerNanolitre should be(1)
+    GramsPerNanolitre(1).toGramsPerNanolitre should be(1)
+    MilligramsPerNanolitre(1).toMilligramsPerNanolitre should be(1)
+    MicrogramsPerNanolitre(1).toMicrogramsPerNanolitre should be(1)
+    NanogramsPerNanolitre(1).toNanogramsPerNanolitre should be(1)
   }
 
   it should "create values from properly formatted Strings" in {
     Density("10.22 kg/m³").get should be(KilogramsPerCubicMeter(10.22))
+    Density("10.22 mg/µl").get should be(MilligramsPerMicrolitre(10.22))
     Density("10.45 zz").failed.get should be(QuantityParseException("Unable to parse Density", "10.45 zz"))
     Density("zz kg/m³").failed.get should be(QuantityParseException("Unable to parse Density", "zz kg/m³"))
   }
@@ -35,14 +56,56 @@ class DensitySpec extends AnyFlatSpec with Matchers {
   it should "properly convert to all supported Units of Measure" in {
     val x = KilogramsPerCubicMeter(1)
     x.toKilogramsPerCubicMeter should be(1)
+    x.toKilogramsPerLitre should be(Kilograms(1).toKilograms / CubicMeters(1).toLitres)
+    x.toGramsPerLitre should be(Kilograms(1).toGrams / CubicMeters(1).toLitres)
+    x.toMilligramsPerLitre should be(Kilograms(1).toMilligrams / CubicMeters(1).toLitres)
+    x.toMicrogramsPerLitre should be(Kilograms(1).toMicrograms / CubicMeters(1).toLitres +- 1E-9)
+    x.toNanogramsPerLitre should be(Kilograms(1).toNanograms / CubicMeters(1).toLitres)
+    x.toKilogramsPerMillilitre should be(Kilograms(1).toKilograms / CubicMeters(1).toMillilitres)
+    x.toGramsPerMillilitre should be(Kilograms(1).toGrams / CubicMeters(1).toMillilitres +- 1E-9)
+    x.toMilligramsPerMillilitre should be(Kilograms(1).toMilligrams / CubicMeters(1).toMillilitres)
+    x.toMicrogramsPerMillilitre should be(Kilograms(1).toMicrograms / CubicMeters(1).toMillilitres +- 1E-9)
+    x.toNanogramsPerMillilitre should be(Kilograms(1).toNanograms / CubicMeters(1).toMillilitres +- 1E-9)
+    x.toKilogramsPerMicrolitre should be(Kilograms(1).toKilograms / CubicMeters(1).toMicrolitres)
+    x.toGramsPerMicrolitre should be(Kilograms(1).toGrams / CubicMeters(1).toMicrolitres +- 1E-7)
+    x.toMilligramsPerMicrolitre should be(Kilograms(1).toMilligrams / CubicMeters(1).toMicrolitres)
+    x.toMicrogramsPerMicrolitre should be(Kilograms(1).toMicrograms / CubicMeters(1).toMicrolitres)
+    x.toNanogramsPerMicrolitre should be(Kilograms(1).toNanograms / CubicMeters(1).toMicrolitres)
+    x.toKilogramsPerNanolitre should be(Kilograms(1).toKilograms / CubicMeters(1).toNanolitres)
+    x.toGramsPerNanolitre should be(Kilograms(1).toGrams / CubicMeters(1).toNanolitres)
+    x.toMilligramsPerNanolitre should be(Kilograms(1).toMilligrams / CubicMeters(1).toNanolitres)
+    x.toMicrogramsPerNanolitre should be(Kilograms(1).toMicrograms / CubicMeters(1).toNanolitres +- 1E-9)
+    x.toNanogramsPerNanolitre should be(Kilograms(1).toNanograms / CubicMeters(1).toNanolitres +- 1E-9)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
     KilogramsPerCubicMeter(1).toString should be("1.0 kg/m³")
+    KilogramsPerLitre(1).toString should be("1.0 kg/L")
+    GramsPerLitre(1).toString should be("1.0 g/L")
+    MilligramsPerLitre(1).toString should be("1.0 mg/L")
+    MicrogramsPerLitre(1).toString should be("1.0 µg/L")
+    NanogramsPerLitre(1).toString should be("1.0 ng/L")
+    KilogramsPerMillilitre(1).toString should be("1.0 kg/ml")
+    GramsPerMillilitre(1).toString should be("1.0 g/ml")
+    MilligramsPerMillilitre(1).toString should be("1.0 mg/ml")
+    MicrogramsPerMillilitre(1).toString should be("1.0 µg/ml")
+    NanogramsPerMillilitre(1).toString should be("1.0 ng/ml")
+    KilogramsPerMicrolitre(1).toString should be("1.0 kg/µl")
+    GramsPerMicrolitre(1).toString should be("1.0 g/µl")
+    MilligramsPerMicrolitre(1).toString should be("1.0 mg/µl")
+    MicrogramsPerMicrolitre(1).toString should be("1.0 µg/µl")
+    NanogramsPerMicrolitre(1).toString should be("1.0 ng/µl")
+    KilogramsPerNanolitre(1).toString should be("1.0 kg/nl")
+    GramsPerNanolitre(1).toString should be("1.0 g/nl")
+    MilligramsPerNanolitre(1).toString should be("1.0 mg/nl")
+    MicrogramsPerNanolitre(1).toString should be("1.0 µg/nl")
+    NanogramsPerNanolitre(1).toString should be("1.0 ng/nl")
   }
 
   it should "return Mass when multiplied by Volume" in {
     KilogramsPerCubicMeter(1) * CubicMeters(1) should be(Kilograms(1))
+    KilogramsPerLitre(1) * Litres(1) should be(Kilograms(1))
+    GramsPerMicrolitre(0.5) * Millilitres(2) should be(Grams(1000))
   }
 
   behavior of "DensityConversion"
@@ -51,6 +114,46 @@ class DensitySpec extends AnyFlatSpec with Matchers {
     import DensityConversions._
 
     kilogramPerCubicMeter should be(KilogramsPerCubicMeter(1))
+    kilogramsPerLitre should be(KilogramsPerLitre(1))
+    kilogramsPerLiter should be(KilogramsPerLitre(1))
+    gramsPerLitre should be(GramsPerLitre(1))
+    gramsPerLiter should be(GramsPerLitre(1))
+    milligramsPerLitre should be(MilligramsPerLitre(1))
+    milligramsPerLiter should be(MilligramsPerLitre(1))
+    microgramsPerLitre should be(MicrogramsPerLitre(1))
+    microgramsPerLiter should be(MicrogramsPerLitre(1))
+    nanogramsPerLitre should be(NanogramsPerLitre(1))
+    nanogramsPerLiter should be(NanogramsPerLitre(1))
+    kilogramsPerMillilitre should be(KilogramsPerMillilitre(1))
+    kilogramsPerMilliliter should be(KilogramsPerMillilitre(1))
+    gramsPerMillilitre should be(GramsPerMillilitre(1))
+    gramsPerMilliliter should be(GramsPerMillilitre(1))
+    milligramsPerMillilitre should be(MilligramsPerMillilitre(1))
+    milligramsPerMilliliter should be(MilligramsPerMillilitre(1))
+    microgramsPerMillilitre should be(MicrogramsPerMillilitre(1))
+    microgramsPerMilliliter should be(MicrogramsPerMillilitre(1))
+    nanogramsPerMillilitre should be(NanogramsPerMillilitre(1))
+    nanogramsPerMilliliter should be(NanogramsPerMillilitre(1))
+    kilogramsPerMicrolitre should be(KilogramsPerMicrolitre(1))
+    kilogramsPerMicroliter should be(KilogramsPerMicrolitre(1))
+    gramsPerMicrolitre should be(GramsPerMicrolitre(1))
+    gramsPerMicroliter should be(GramsPerMicrolitre(1))
+    milligramsPerMicrolitre should be(MilligramsPerMicrolitre(1))
+    milligramsPerMicroliter should be(MilligramsPerMicrolitre(1))
+    microgramsPerMicrolitre should be(MicrogramsPerMicrolitre(1))
+    microgramsPerMicroliter should be(MicrogramsPerMicrolitre(1))
+    nanogramsPerMicrolitre should be(NanogramsPerMicrolitre(1))
+    nanogramsPerMicroliter should be(NanogramsPerMicrolitre(1))
+    kilogramsPerNanolitre should be(KilogramsPerNanolitre(1))
+    kilogramsPerNanoliter should be(KilogramsPerNanolitre(1))
+    gramsPerNanolitre should be(GramsPerNanolitre(1))
+    gramsPerNanoliter should be(GramsPerNanolitre(1))
+    milligramsPerNanolitre should be(MilligramsPerNanolitre(1))
+    milligramsPerNanoliter should be(MilligramsPerNanolitre(1))
+    microgramsPerNanolitre should be(MicrogramsPerNanolitre(1))
+    microgramsPerNanoliter should be(MicrogramsPerNanolitre(1))
+    nanogramsPerNanolitre should be(NanogramsPerNanolitre(1))
+    nanogramsPerNanoliter should be(NanogramsPerNanolitre(1))
   }
 
   it should "provide implicit conversion from Double" in {
@@ -58,12 +161,32 @@ class DensitySpec extends AnyFlatSpec with Matchers {
 
     val d = 10.22d
     d.kilogramsPerCubicMeter should be(KilogramsPerCubicMeter(d))
+    d.kilogramsPerLitre should be(KilogramsPerLitre(d))
+    d.gramsPerLitre should be(GramsPerLitre(d))
+    d.milligramsPerLitre should be(MilligramsPerLitre(d))
+    d.microgramsPerLitre should be(MicrogramsPerLitre(d))
+    d.nanogramsPerLitre should be(NanogramsPerLitre(d))
+    d.kilogramsPerMillilitre should be(KilogramsPerMillilitre(d))
+    d.gramsPerMillilitre should be(GramsPerMillilitre(d))
+    d.milligramsPerMillilitre should be(MilligramsPerMillilitre(d))
+    d.microgramsPerMillilitre should be(MicrogramsPerMillilitre(d))
+    d.nanogramsPerMillilitre should be(NanogramsPerMillilitre(d))
+    d.kilogramsPerMicrolitre should be(KilogramsPerMicrolitre(d))
+    d.gramsPerMicrolitre should be(GramsPerMicrolitre(d))
+    d.milligramsPerMicrolitre should be(MilligramsPerMicrolitre(d))
+    d.microgramsPerMicrolitre should be(MicrogramsPerMicrolitre(d))
+    d.nanogramsPerMicrolitre should be(NanogramsPerMicrolitre(d))
+    d.kilogramsPerNanolitre should be(KilogramsPerNanolitre(d))
+    d.gramsPerNanolitre should be(GramsPerNanolitre(d))
+    d.milligramsPerNanolitre should be(MilligramsPerNanolitre(d))
+    d.microgramsPerNanolitre should be(MicrogramsPerNanolitre(d))
+    d.nanogramsPerNanolitre should be(NanogramsPerNanolitre(d))
   }
 
   it should "provide Numeric support" in {
     import DensityConversions.DensityNumeric
 
-    val as = List(KilogramsPerCubicMeter(100), KilogramsPerCubicMeter(10))
-    as.sum should be(KilogramsPerCubicMeter(110))
+    val as = List(KilogramsPerCubicMeter(2), MicrogramsPerMillilitre(500))
+    as.sum should be(KilogramsPerCubicMeter(2.5))
   }
 }


### PR DESCRIPTION
Add density units for all combinations of kilo, milli, micro and nano
grams per kilo, milli, micro and nano litres.

Fixed bug with existing multiplication conversion and explicitly typed
all return values for Density class and object.