### PR TITLE
Add Thai Baht (บาทไทย) support 🇹🇭

### DIFF
--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -490,8 +490,8 @@ object LTC extends Currency("LTC", "Litecoin", "\u0141", 8)
 object ZAR extends Currency("ZAR", "South African Rand", "R", 2)
 object NAD extends Currency("NAD", "Namibian Dollar", "N$", 2)
 object TRY extends Currency("TRY", "Turkish lira", "₺", 2)
-
 object UAH extends Currency("UAH", "Ukrainian Hryvnia", "₴", 2)
+object THB extends Currency("THB", "Thai Baht", "฿", 2)
 
 /**
  * Support for Money DSL
@@ -534,8 +534,9 @@ object MoneyConversions {
     def ZAR = Money(n, squants.market.ZAR)
     def NAD = Money(n, squants.market.NAD)
     def TRY = Money(n, squants.market.TRY)
-
     def UAH = Money(n, squants.market.UAH)
+    def THB = Money(n, squants.market.THB)
+    def satang = Money(num.toDouble(n) / 100d, squants.market.THB)
   }
 
   class MoneyNumeric()(implicit mc: MoneyContext) extends Numeric[Money] {

--- a/shared/src/main/scala/squants/market/package.scala
+++ b/shared/src/main/scala/squants/market/package.scala
@@ -62,7 +62,7 @@ package object market {
     KRW, MXN, MYR, NOK, NZD,
     RUB, SEK, XAG, XAU, BTC,
     ETH, LTC, ZAR, NAD, TRY,
-    UAH
+    UAH, THB
   )
 
   lazy val defaultMoneyContext = MoneyContext(USD, defaultCurrencySet, Nil)

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -497,6 +497,8 @@ class MoneySpec extends AnyFlatSpec with Matchers with TryValues {
     d.NAD should be(NAD(d))
     d.TRY should be(TRY(d))
     d.UAH should be(UAH(d))
+    d.THB should be(THB(d))
+    d.satang should be(Money(d / 100d, squants.market.THB))
   }
 
   it should "provide Numeric support within a MoneyContext with no Exchange Rates" in {


### PR DESCRIPTION
Thai Baht has been a decimalized currency since 1897 officially (implemented 1910). Satang is the sub-unit. 1 THB = 100 satang.