### PR TITLE
Update Scala, test & plugin libraries, then fixed code warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ project/plugins/project/
 .lib/
 .bloop/
 .metals/
+.bsp/
 
 # Java
 *.class
@@ -55,3 +56,6 @@ project/metals.sbt
 # Windows
 Desktop.ini
 Thumbs.db
+
+# VScode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1455,7 +1455,7 @@ class ScadaLoadListener(router: Router) extends Actor {
   def receive = {
    // ScadaLoadReading - from an external service - sends load as a string
    // eg, “10.3 MW”, “345 kW”
-   case msg @ ScadaLoadReading(meterId, time, loadString) ⇒
+   case msg @ ScadaLoadReading(meterId, time, loadString) =>
     // Parse the string and on success emit the Squants enabled event to routees
     Power(loadString) match {
       case Success(p) => router.route(LoadReading(meterId, time, p), sender())

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,13 +7,13 @@ import com.typesafe.sbt.osgi.SbtOsgi
 import com.typesafe.sbt.osgi.SbtOsgi.autoImport._
 
 object Versions {
-  val Scala3 = "3.1.1"
+  val Scala3 = "3.7.1"
   val Scala = Scala3
   val ScalaCross =
     Seq("2.12.15", "2.13.6", Scala)
 
-  val ScalaTest = "3.2.14"
-  val ScalaCheck = "1.16.0"
+  val ScalaTest = "3.2.19"
+  val ScalaCheck = "1.18.1"
 }
 
 object Dependencies {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2") // https://github.com/portable-scala/sbt-crossproject
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.19.0") // https://www.scala-js.org
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2") // https://github.com/portable-scala/sbt-crossproject
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.8") // https://scala-native.org/en/stable/index.html
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.19.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.8")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.2.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.10.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.9")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2") // https://github.com/portable-scala/sbt-crossproject
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.19.0") // https://www.scala-js.org
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2") // https://github.com/portable-scala/sbt-crossproject
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.8") // https://scala-native.org/en/stable/index.html
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 

--- a/shared/src/main/scala/squants/AbstractQuantityNumeric.scala
+++ b/shared/src/main/scala/squants/AbstractQuantityNumeric.scala
@@ -15,7 +15,7 @@ package squants
  *
  * @tparam A Quantity type
  */
-abstract class AbstractQuantityNumeric[A <: Quantity[A]](val unit: UnitOfMeasure[A] with PrimaryUnit) extends Numeric[A] {
+abstract class AbstractQuantityNumeric[A <: Quantity[A]](val unit: UnitOfMeasure[A] & PrimaryUnit) extends Numeric[A] {
   def plus(x: A, y: A) = x + y
   def minus(x: A, y: A) = x - y
 

--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -35,20 +35,20 @@ trait Dimension[A <: Quantity[A]] {
    * The conversionFactor for other units should be set relative to this unit.
    * @return
    */
-  def primaryUnit: UnitOfMeasure[A] with PrimaryUnit
+  def primaryUnit: UnitOfMeasure[A] & PrimaryUnit
 
   /**
    * The International System of Units (SI) Base Unit
    * @return
    */
-  def siUnit: UnitOfMeasure[A] with SiUnit
+  def siUnit: UnitOfMeasure[A] & SiUnit
 
   /**
    * Maps a string representation of a unit symbol into the matching UnitOfMeasure object
    * @param symbol String
    * @return
    */
-  def symbolToUnit(symbol: String): Option[UnitOfMeasure[A]] = units.find(u ⇒ u.symbol == symbol)
+  def symbolToUnit(symbol: String): Option[UnitOfMeasure[A]] = units.find(u => u.symbol == symbol)
 
   /**
    * Tries to map a string or tuple value to Quantity of this Dimension
@@ -56,20 +56,20 @@ trait Dimension[A <: Quantity[A]] {
    * @return Try[A]
    */
   protected def parse(value: Any): Try[A] = value match {
-    case s: String              ⇒ parseString(s)
-    case (v: Byte, u: String)   ⇒ parseTuple((v, u))
-    case (v: Short, u: String)  ⇒ parseTuple((v, u))
-    case (v: Int, u: String)    ⇒ parseTuple((v, u))
-    case (v: Long, u: String)   ⇒ parseTuple((v, u))
-    case (v: Float, u: String)  ⇒ parseTuple((v, u))
-    case (v: Double, u: String) ⇒ parseTuple((v, u))
-    case _ ⇒ Failure(QuantityParseException(s"Unable to parse $name", value.toString))
+    case s: String              => parseString(s)
+    case (v: Byte, u: String)   => parseTuple((v, u))
+    case (v: Short, u: String)  => parseTuple((v, u))
+    case (v: Int, u: String)    => parseTuple((v, u))
+    case (v: Long, u: String)   => parseTuple((v, u))
+    case (v: Float, u: String)  => parseTuple((v, u))
+    case (v: Double, u: String) => parseTuple((v, u))
+    case _ => Failure(QuantityParseException(s"Unable to parse $name", value.toString))
   }
 
   def parseString(s: String): Try[A] = {
     s match {
-      case QuantityString(value, symbol) ⇒ Success(symbolToUnit(symbol).get(BigDecimal(value)))
-      case _                             ⇒ Failure(QuantityParseException(s"Unable to parse $name", s))
+      case QuantityString(value, symbol) => Success(symbolToUnit(symbol).get(BigDecimal(value)))
+      case _                             => Failure(QuantityParseException(s"Unable to parse $name", s))
     }
   }
   
@@ -79,8 +79,8 @@ trait Dimension[A <: Quantity[A]] {
     val value = t._1
     val symbol = t._2
     symbolToUnit(symbol) match {
-      case Some(unit) ⇒ Success(unit(value))
-      case None       ⇒ Failure(QuantityParseException(s"Unable to identify $name unit ${symbol}", s"(${Platform.crossFormat(num.toDouble(value))},${symbol})"))
+      case Some(unit) => Success(unit(value))
+      case None       => Failure(QuantityParseException(s"Unable to identify $name unit ${symbol}", s"(${Platform.crossFormat(num.toDouble(value))},${symbol})"))
     }
   }
 
@@ -100,7 +100,7 @@ case class QuantityParseException(message: String, expression: String) extends E
 /**
  * SI Base Quantity
  */
-trait BaseDimension { self: Dimension[_] ⇒
+trait BaseDimension { self: Dimension[?] =>
   /**
    * SI Base Unit for this Quantity
    * @return

--- a/shared/src/main/scala/squants/Dimensionless.scala
+++ b/shared/src/main/scala/squants/Dimensionless.scala
@@ -31,7 +31,7 @@ final class Dimensionless private (val value: Double, val unit: DimensionlessUni
   protected[squants] def time = Seconds(1)
 
   def *(that: Dimensionless) = Each(toEach * that.toEach)
-  def *(that: Quantity[_]) = that * toEach
+  def *(that: Quantity[?]) = that * toEach
 
   def +(that: Double): Dimensionless = this + Each(that)
 

--- a/shared/src/main/scala/squants/Quantity.scala
+++ b/shared/src/main/scala/squants/Quantity.scala
@@ -20,7 +20,7 @@ import scala.math.BigDecimal.RoundingMode.RoundingMode
  * @since   0.1
  *
  */
-abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] { self: A ⇒
+abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] { self: A =>
 
   /**
    * The value of the quantity given the unit
@@ -104,7 +104,7 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @return (Quantity, Quantity)
    */
   def divideAndRemainder(that: Double): (A, A) = BigDecimal(value) /% that match {
-    case (q, r) ⇒ (unit(q.toDouble), unit(r.toDouble))
+    case (q, r) => (unit(q.toDouble), unit(r.toDouble))
   }
   def /%(that: Double) = divideAndRemainder(that)
 
@@ -114,7 +114,7 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @return (Double, Quantity)
    */
   def divideAndRemainder(that: A): (Double, A) = BigDecimal(value) /% that.to(unit) match {
-    case (q, r) ⇒ (q.toDouble, unit(r.toDouble))
+    case (q, r) => (q.toDouble, unit(r.toDouble))
   }
   def /%(that: A) = divideAndRemainder(that)
 
@@ -171,8 +171,8 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @return
    */
   override def equals(that: Any) = that match {
-    case x: Quantity[_] if x.dimension == dimension ⇒ value == x.asInstanceOf[Quantity[A]].to(unit)
-    case _ ⇒ false
+    case x: Quantity[_] if x.dimension == dimension => value == x.asInstanceOf[Quantity[A]].to(unit)
+    case _ => false
   }
 
   /**
@@ -190,7 +190,7 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @param tolerance Quantity
    * @return
    */
-  def approx(that: A)(implicit tolerance: A) = that within this.plusOrMinus(tolerance)
+  def approx(that: A)(implicit tolerance: A) = that.within(this.plusOrMinus(tolerance))
   /** approx */
   def =~(that: A)(implicit tolerance: A) = approx(that)
   /** approx */
@@ -258,8 +258,8 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @return Double
    */
   def to(uom: UnitOfMeasure[A]): Double = uom match {
-    case u if u == this.unit ⇒ value
-    case _                   ⇒ uom.convertTo(this.unit.convertFrom(value))
+    case u if u == this.unit => value
+    case _                   => uom.convertTo(this.unit.convertFrom(value))
   }
 
   /**
@@ -268,8 +268,8 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @return Quantity
    */
   def in(uom: UnitOfMeasure[A]) = uom match {
-    case u if u == this.unit ⇒ this
-    case _                   ⇒ uom(uom.convertTo(this.unit.convertFrom(value)))
+    case u if u == this.unit => this
+    case _                   => uom(uom.convertTo(this.unit.convertFrom(value)))
   }
 
   /**
@@ -311,6 +311,6 @@ abstract class Quantity[A <: Quantity[A]] extends Serializable with Ordered[A] {
    * @param f Double => Double function
    * @return
    */
-  def map(f: Double ⇒ Double): A = unit(f(value))
+  def map(f: Double => Double): A = unit(f(value))
 }
 

--- a/shared/src/main/scala/squants/QuantityRange.scala
+++ b/shared/src/main/scala/squants/QuantityRange.scala
@@ -36,7 +36,7 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
   def times(multiple: Double): QuantitySeries[A] = {
     val remainder = multiple % 1
     val count = ((multiple - remainder) / 1).toInt
-    val ranges = (0 until count).map(n ⇒ QuantityRange(lower + (toQuantity * n.toDouble), upper + (toQuantity * n.toDouble)))
+    val ranges = (0 until count).map(n => QuantityRange(lower + (toQuantity * n.toDouble), upper + (toQuantity * n.toDouble)))
     if (remainder > 0) ranges :+ QuantityRange(lower + (toQuantity * count.toDouble), lower + (toQuantity * (count + remainder)))
     else ranges
   }
@@ -58,7 +58,7 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
     @tailrec
     def accumulate(acc: QuantitySeries[A], start: A): QuantitySeries[A] = {
       if (start >= upper) acc
-      else accumulate(acc :+ (start to (start + that).min(upper)), start + that)
+      else accumulate(acc :+ (start.to((start + that).min(upper))), start + that)
     }
     accumulate(IndexedSeq.empty.asInstanceOf[QuantitySeries[A]], lower)
   }
@@ -89,7 +89,7 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @param op the side affecting operation
    * @return
    */
-  def foreach[U](size: A)(op: QuantityRange[A] ⇒ U) = /(size).foreach(op)
+  def foreach[U](size: A)(op: QuantityRange[A] => U) = /(size).foreach(op)
 
   /**
    * Divides the range into a Seq of `divisor` ranges and applies a f to each element
@@ -98,7 +98,7 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @param op the side affecting operation
    * @return
    */
-  def foreach[U](divisor: Double)(op: QuantityRange[A] ⇒ U) = /(divisor).foreach(op)
+  def foreach[U](divisor: Double)(op: QuantityRange[A] => U) = /(divisor).foreach(op)
 
   /**
    * Divides the range into a Seq of ranges of `size` each and applies a map operation to each
@@ -108,7 +108,7 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @tparam B the result type of the map operation
    * @return
    */
-  def map[B](size: A)(op: QuantityRange[A] ⇒ B): Seq[B] = /(size).map(op)
+  def map[B](size: A)(op: QuantityRange[A] => B): Seq[B] = /(size).map(op)
 
   /**
    * Divides the range into a Seq of `divisor` ranges and applies a map operation to each
@@ -118,7 +118,7 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @tparam B the result type of the map operation
    * @return
    */
-  def map[B](divisor: Double)(op: QuantityRange[A] ⇒ B): Seq[B] = map(toQuantity / divisor)(op)
+  def map[B](divisor: Double)(op: QuantityRange[A] => B): Seq[B] = map(toQuantity / divisor)(op)
 
   /**
    * Divides the range into a Seq of ranges of `size` each and applies a foldLeft operation
@@ -129,9 +129,9 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @tparam B the result type of the binary operator
    * @return
    */
-  def foldLeft[B](size: A, z: B)(op: (B, QuantityRange[A]) ⇒ B): B = /(size).foldLeft[B](z)(op)
+  def foldLeft[B](size: A, z: B)(op: (B, QuantityRange[A]) => B): B = /(size).foldLeft[B](z)(op)
   /** foldLeft */
-  def /:[B](size: A, z: B)(op: (B, QuantityRange[A]) ⇒ B) = foldLeft(size, z)(op)
+  def /:[B](size: A, z: B)(op: (B, QuantityRange[A]) => B) = foldLeft(size, z)(op)
 
   /**
    * Divides the range into a Seq of ranges of `size` each and applies a foldLeft operation
@@ -142,9 +142,9 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @tparam B the result type of the binary operator
    * @return
    */
-  def foldLeft[B](divisor: Double, z: B)(op: (B, QuantityRange[A]) ⇒ B): B = /(divisor).foldLeft[B](z)(op)
+  def foldLeft[B](divisor: Double, z: B)(op: (B, QuantityRange[A]) => B): B = /(divisor).foldLeft[B](z)(op)
   /** foldLeft */
-  def /:[B](divisor: Double, z: B)(op: (B, QuantityRange[A]) ⇒ B) = foldLeft(divisor, z)(op)
+  def /:[B](divisor: Double, z: B)(op: (B, QuantityRange[A]) => B) = foldLeft(divisor, z)(op)
 
   /**
    * Divides the range into a Seq of ranges of `size` each and applies a foldRight operation
@@ -155,9 +155,9 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @tparam B the result type of the binary operator
    * @return
    */
-  def foldRight[B](size: A, z: B)(op: (QuantityRange[A], B) ⇒ B): B = /(size).foldRight[B](z)(op)
+  def foldRight[B](size: A, z: B)(op: (QuantityRange[A], B) => B): B = /(size).foldRight[B](z)(op)
   /** foldRight */
-  def :\[B](size: A, z: B)(op: (QuantityRange[A], B) ⇒ B) = foldRight(size, z)(op)
+  def :\[B](size: A, z: B)(op: (QuantityRange[A], B) => B) = foldRight(size, z)(op)
 
   /**
    * Divides the range into a Seq of ranges of `size` each and applies a foldRight operation
@@ -168,9 +168,9 @@ case class QuantityRange[A <: Quantity[A]](lower: A, upper: A) {
    * @tparam B the result type of the binary operator
    * @return
    */
-  def foldRight[B](divisor: Double, z: B)(op: (QuantityRange[A], B) ⇒ B): B = /(divisor).foldRight[B](z)(op)
+  def foldRight[B](divisor: Double, z: B)(op: (QuantityRange[A], B) => B): B = /(divisor).foldRight[B](z)(op)
   /** foldRight */
-  def :\[B](divisor: Double, z: B)(op: (QuantityRange[A], B) ⇒ B) = foldRight(divisor, z)(op)
+  def :\[B](divisor: Double, z: B)(op: (QuantityRange[A], B) => B) = foldRight(divisor, z)(op)
 
   /**
    * Increments the range's from and to values by an amount equal to the Quantity value of the range

--- a/shared/src/main/scala/squants/SVector.scala
+++ b/shared/src/main/scala/squants/SVector.scala
@@ -64,7 +64,7 @@ trait SVector[A] {
    * @return
    */
   def plus(that: SVectorType): SVectorType
-  def + = plus _
+  def + = plus
 
   /**
    * Subtract two Vectors
@@ -72,7 +72,7 @@ trait SVector[A] {
    * @return
    */
   def minus(that: SVectorType): SVectorType
-  def - = minus _
+  def - = minus
 
   /**
    * Scale a Vector
@@ -105,14 +105,14 @@ trait SVector[A] {
    * @return
    */
   def crossProduct(that: DoubleVector): SVector[A]
-  def #* = crossProduct _
+  def #* = crossProduct
 
 }
 
 object SVector {
 
-  def apply(coordinates: Double*): DoubleVector = DoubleVector(coordinates: _*)
-  def apply[A <: Quantity[A]](coordinates: A*): QuantityVector[A] = QuantityVector[A](coordinates: _*)
+  def apply(coordinates: Double*): DoubleVector = DoubleVector(coordinates*)
+  def apply[A <: Quantity[A]](coordinates: A*): QuantityVector[A] = QuantityVector[A](coordinates*)
 
   /**
    * Create a 2-dimensional DoubleVector from Polar Coordinates
@@ -144,9 +144,9 @@ case class DoubleVector(coordinates: Double*) extends SVector[Double] {
 
   type SVectorType = DoubleVector
 
-  def magnitude: Double = math.sqrt(coordinates.map(v ⇒ v * v).sum)
+  def magnitude: Double = math.sqrt(coordinates.map(v => v * v).sum)
   def angle(coordinateX: Int = 0, coordinateY: Int = 1, unit: AngleUnit = Radians): Angle =
-    Radians(math.atan2(coordinates(coordinateY), coordinates(coordinateX))) in unit
+    Radians(math.atan2(coordinates(coordinateY), coordinates(coordinateX))).in(unit)
 
   def normalize: SVectorType = this.divide(magnitude)
 
@@ -155,7 +155,7 @@ case class DoubleVector(coordinates: Double*) extends SVector[Double] {
    * @param f A => Double map function
    * @return
    */
-  def map[A <: Double](f: Double ⇒ Double): DoubleVector = DoubleVector(coordinates.map(f): _*)
+  def map[A <: Double](f: Double => Double): DoubleVector = DoubleVector(coordinates.map(f)*)
 
   /**
    * Creates a QuantityVector by mapping over each coordinate with the supplied function
@@ -163,13 +163,13 @@ case class DoubleVector(coordinates: Double*) extends SVector[Double] {
    * @tparam A <: Quantity
    * @return
    */
-  def map[A <: Quantity[A]](f: Double ⇒ A): QuantityVector[A] = QuantityVector(coordinates.map(f): _*)
+  def map[A <: Quantity[A]](f: Double => A): QuantityVector[A] = QuantityVector(coordinates.map(f)*)
 
   def plus(that: SVectorType): SVectorType =
-    DoubleVector(coordinates.toIterable.zipAll(that.coordinates, 0d, 0d).map(v ⇒ v._1 + v._2).toSeq: _*)
+    DoubleVector(coordinates.toSeq.zipAll(that.coordinates, 0d, 0d).map(v => v._1 + v._2)*)
 
   def minus(that: SVectorType): SVectorType =
-    DoubleVector(coordinates.toIterable.zipAll(that.coordinates, 0d, 0d).map(v ⇒ v._1 - v._2).toSeq: _*)
+    DoubleVector(coordinates.toSeq.zipAll(that.coordinates, 0d, 0d).map(v => v._1 - v._2)*)
 
   def times(that: Double): SVectorType = map(_ * that)
   def times[A <: Quantity[A]](that: A): QuantityVector[A] = map(_ * that)
@@ -177,20 +177,20 @@ case class DoubleVector(coordinates: Double*) extends SVector[Double] {
   def divide(that: Double): SVectorType = map(_ / that)
 
   def dotProduct(that: SVectorType): Double =
-    coordinates.toIterable.zipAll(that.coordinates, 0d, 0d).map(v ⇒ v._1 * v._2).sum
+    coordinates.toSeq.zipAll(that.coordinates, 0d, 0d).map(v => v._1 * v._2).sum
 
-  def dotProduct[B <: Quantity[B]](that: QuantityVector[B]) = that dotProduct this
+  def dotProduct[B <: Quantity[B]](that: QuantityVector[B]) = that.dotProduct(this)
 
   def crossProduct(that: SVectorType) = (this.coordinates.length, that.coordinates.length) match {
-    case (3, 3) ⇒
+    case (3, 3) =>
       DoubleVector(this.coordinates(1) * that.coordinates(2) - this.coordinates(2) * that.coordinates(1),
         coordinates(2) * that.coordinates(0) - this.coordinates(0) * that.coordinates(2),
         coordinates(0) * that.coordinates(1) - this.coordinates(1) * that.coordinates(0))
-    case (7, 7) ⇒ throw new UnsupportedOperationException("Seven-dimensional cross product is not currently supported")
-    case _      ⇒ throw new UnsupportedOperationException("Cross product is not supported on vectors with an arbitrary number of dimensions")
+    case (7, 7) => throw new UnsupportedOperationException("Seven-dimensional cross product is not currently supported")
+    case _      => throw new UnsupportedOperationException("Cross product is not supported on vectors with an arbitrary number of dimensions")
   }
 
-  def crossProduct[B <: Quantity[B]](that: QuantityVector[B]) = that crossProduct this
+  def crossProduct[B <: Quantity[B]](that: QuantityVector[B]) = that.crossProduct(this)
 
 }
 
@@ -207,9 +207,9 @@ case class QuantityVector[A <: Quantity[A]](coordinates: A*) extends SVector[A] 
   type SVectorType = QuantityVector[A]
 
   def valueUnit = coordinates(0).unit
-  def magnitude: A = valueUnit(math.sqrt(coordinates.map(v ⇒ v.to(valueUnit) * v.to(valueUnit)).sum))
+  def magnitude: A = valueUnit(math.sqrt(coordinates.map(v => v.to(valueUnit) * v.to(valueUnit)).sum))
   def angle(coordinateX: Int = 0, coordinateY: Int = 1, unit: AngleUnit = Radians): Angle =
-    Radians(math.atan(coordinates(coordinateY) / coordinates(coordinateX))) in unit
+    Radians(math.atan(coordinates(coordinateY) / coordinates(coordinateX))).in(unit)
 
   def normalize: SVectorType = this / magnitude.to(valueUnit)
 
@@ -224,7 +224,7 @@ case class QuantityVector[A <: Quantity[A]](coordinates: A*) extends SVector[A] 
    * @param f A => Double map function
    * @return
    */
-  def map[B <: Double](f: A ⇒ Double): DoubleVector = DoubleVector(coordinates.map(f): _*)
+  def map[B <: Double](f: A => Double): DoubleVector = DoubleVector(coordinates.map(f)*)
 
   /**
    * Creates a QuantityVector by mapping over each coordinate with the supplied function
@@ -232,49 +232,49 @@ case class QuantityVector[A <: Quantity[A]](coordinates: A*) extends SVector[A] 
    * @tparam B <: Quantity
    * @return
    */
-  def map[B <: Quantity[B]](f: A ⇒ B): QuantityVector[B] = QuantityVector(coordinates.map(f): _*)
+  def map[B <: Quantity[B]](f: A => B): QuantityVector[B] = QuantityVector(coordinates.map(f)*)
 
   def plus(that: SVectorType): SVectorType =
-    QuantityVector(coordinates.zipAll(that.coordinates, valueUnit(0), valueUnit(0)).map(v ⇒ v._1 + v._2): _*)
+    QuantityVector(coordinates.zipAll(that.coordinates, valueUnit(0), valueUnit(0)).map(v => v._1 + v._2)*)
   def minus(that: SVectorType): SVectorType =
-    QuantityVector(coordinates.zipAll(that.coordinates, valueUnit(0), valueUnit(0)).map(v ⇒ v._1 - v._2): _*)
+    QuantityVector(coordinates.zipAll(that.coordinates, valueUnit(0), valueUnit(0)).map(v => v._1 - v._2)*)
 
   def times(that: Double): SVectorType = map(_ * that)
 
-  def times[B <: Quantity[B], C <: Quantity[C]](quantTimes: A ⇒ C): QuantityVector[C] = map(quantTimes)
+  def times[B <: Quantity[B], C <: Quantity[C]](quantTimes: A => C): QuantityVector[C] = map(quantTimes)
 
   def divide(that: Double): SVectorType = map(_ / that)
 
   def divide(that: A): DoubleVector = map(_ / that)
   def /(that: A) = divide(that)
 
-  def divide[B <: Quantity[B], C <: Quantity[C]](quantDiv: A ⇒ C): QuantityVector[C] = map(quantDiv(_))
+  def divide[B <: Quantity[B], C <: Quantity[C]](quantDiv: A => C): QuantityVector[C] = map(quantDiv(_))
 
   def dotProduct(that: DoubleVector): A =
-    valueUnit(coordinates.zipAll(that.coordinates, valueUnit(0), 0d).map(v ⇒ v._1.to(valueUnit) * v._2).sum)
+    valueUnit(coordinates.zipAll(that.coordinates, valueUnit(0), 0d).map(v => v._1.to(valueUnit) * v._2).sum)
 
-  def dotProduct[B <: Quantity[B], C <: Quantity[C]](that: SVector[B], quantTimes: (A, B) ⇒ C)(implicit num: Numeric[C]): C =
-    coordinates.zipAll(that.coordinates, valueUnit(0), that.coordinates.head.unit(0)).map(v ⇒ quantTimes(v._1, v._2)).sum
+  def dotProduct[B <: Quantity[B], C <: Quantity[C]](that: SVector[B], quantTimes: (A, B) => C)(implicit num: Numeric[C]): C =
+    coordinates.zipAll(that.coordinates, valueUnit(0), that.coordinates.head.unit(0)).map(v => quantTimes(v._1, v._2)).sum
 
   def crossProduct(that: DoubleVector): SVectorType = (this.coordinates.length, that.coordinates.length) match {
-    case (3, 3) ⇒
+    case (3, 3) =>
       QuantityVector(
         (this.coordinates(1) * that.coordinates(2)) - (this.coordinates(2) * that.coordinates(1)),
         (this.coordinates(2) * that.coordinates(0)) - (this.coordinates(0) * that.coordinates(2)),
         (this.coordinates(0) * that.coordinates(1)) - (this.coordinates(1) * that.coordinates(0)))
-    case (7, 7) ⇒ throw new UnsupportedOperationException("Seven-dimensional Cross Product is not currently supported")
-    case _      ⇒ throw new UnsupportedOperationException("Cross Product is not supported on vectors with an arbitrary number of dimensions")
+    case (7, 7) => throw new UnsupportedOperationException("Seven-dimensional Cross Product is not currently supported")
+    case _      => throw new UnsupportedOperationException("Cross Product is not supported on vectors with an arbitrary number of dimensions")
   }
 
-  def crossProduct[B <: Quantity[B], C <: Quantity[C]](that: SVector[B], quantTimes: (A, B) ⇒ C): QuantityVector[C] = {
+  def crossProduct[B <: Quantity[B], C <: Quantity[C]](that: SVector[B], quantTimes: (A, B) => C): QuantityVector[C] = {
     (this.coordinates.length, that.coordinates.length) match {
-      case (3, 3) ⇒
+      case (3, 3) =>
         QuantityVector(
           quantTimes(this.coordinates(1), that.coordinates(2)) - quantTimes(coordinates(2), that.coordinates(1)),
           quantTimes(this.coordinates(2), that.coordinates(0)) - quantTimes(coordinates(0), that.coordinates(2)),
           quantTimes(this.coordinates(0), that.coordinates(1)) - quantTimes(coordinates(1), that.coordinates(0)))
-      case (7, 7) ⇒ throw new UnsupportedOperationException("Seven-dimensional Cross Product is not currently supported")
-      case _      ⇒ throw new UnsupportedOperationException("Cross Product is not supported on vectors with an arbitrary number of dimensions")
+      case (7, 7) => throw new UnsupportedOperationException("Seven-dimensional Cross Product is not currently supported")
+      case _      => throw new UnsupportedOperationException("Cross Product is not supported on vectors with an arbitrary number of dimensions")
     }
   }
 

--- a/shared/src/main/scala/squants/UnitOfMeasure.scala
+++ b/shared/src/main/scala/squants/UnitOfMeasure.scala
@@ -44,13 +44,13 @@ trait UnitOfMeasure[A <: Quantity[A]] extends Serializable {
    * Defines a signature for converting a quantity from this UOM to the Value UOM
    * @return
    */
-  protected def converterFrom: Double ⇒ Double
+  protected def converterFrom: Double => Double
 
   /**
    * Defines a signature for converting a quantity to this UOM from the Value UOM
    * @return
    */
-  protected def converterTo: Double ⇒ Double
+  protected def converterTo: Double => Double
 
   /**
    * Applies the converterTo method to a value
@@ -75,7 +75,7 @@ trait UnitOfMeasure[A <: Quantity[A]] extends Serializable {
 /**
  * A Unit of Measure that require a simple multiplier for converting to and from the underlying value's unit
  */
-trait UnitConverter { uom: UnitOfMeasure[_] ⇒
+trait UnitConverter { uom: UnitOfMeasure[?] =>
 
   /**
    * Defines a multiplier value relative to the Quantity's [[squants.PrimaryUnit]]
@@ -88,13 +88,13 @@ trait UnitConverter { uom: UnitOfMeasure[_] ⇒
    * Implements the converterTo method as a simple quotient of the value and the multiplier
    * @return
    */
-  protected def converterTo: Double ⇒ Double = value ⇒ value / conversionFactor
+  protected def converterTo: Double => Double = value => value / conversionFactor
 
   /**
    * Implements the converterFrom method as a simple product of the value and the multiplier
    * @return
    */
-  protected def converterFrom: Double ⇒ Double = value ⇒ value * conversionFactor
+  protected def converterFrom: Double => Double = value => value * conversionFactor
 }
 
 /**
@@ -104,19 +104,19 @@ trait UnitConverter { uom: UnitOfMeasure[_] ⇒
  *
  * Each Quantity should have one and only one ValueUnit
  */
-trait PrimaryUnit extends UnitConverter { uom: UnitOfMeasure[_] ⇒
+trait PrimaryUnit extends UnitConverter { uom: UnitOfMeasure[?] =>
 
   /**
    * Implements the converterTo method to just return the underlying value
    * @return
    */
-  override final def converterTo: Double ⇒ Double = value ⇒ value
+  override final def converterTo: Double => Double = value => value
 
   /**
    * Implements the converterFrom method to just return the underlying value
    * @return
    */
-  override final def converterFrom: Double ⇒ Double = value ⇒ value
+  override final def converterFrom: Double => Double = value => value
 
   /**
    * Value unit multiplier is always equal to 1

--- a/shared/src/main/scala/squants/market/CurrencyExchangeRate.scala
+++ b/shared/src/main/scala/squants/market/CurrencyExchangeRate.scala
@@ -35,9 +35,9 @@ case class CurrencyExchangeRate(base: Money, counter: Money) extends Ratio[Money
    * @return
    */
   def convert(money: Money) = money.currency match {
-    case base.currency    ⇒ convertToCounter(money)
-    case counter.currency ⇒ convertToBase(money)
-    case _                ⇒ throw new IllegalArgumentException("The currency of money must match the currency of base or counter")
+    case base.currency    => convertToCounter(money)
+    case counter.currency => convertToBase(money)
+    case _                => throw new IllegalArgumentException("The currency of money must match the currency of base or counter")
   }
 
   /** convert  */

--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -100,8 +100,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @throws scala.UnsupportedOperationException when attempted on cross currencies
    */
   override def plus(that: Money): Money = that.currency match {
-    case this.currency ⇒ new Money(this.amount + that.amount)(currency)
-    case _             ⇒ throw new UnsupportedOperationException("plus not supported for cross-currency comparison - use moneyPlus")
+    case this.currency => new Money(this.amount + that.amount)(currency)
+    case _             => throw new UnsupportedOperationException("plus not supported for cross-currency comparison - use moneyPlus")
   }
 
   /**
@@ -125,8 +125,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @throws scala.UnsupportedOperationException when attempted on cross currencies
    */
   override def minus(that: Money): Money = that.currency match {
-    case this.currency ⇒ new Money(this.amount - that.amount)(currency)
-    case _             ⇒ throw new UnsupportedOperationException("minus not supported for cross-currency comparison - use moneyMinus")
+    case this.currency => new Money(this.amount - that.amount)(currency)
+    case _             => throw new UnsupportedOperationException("minus not supported for cross-currency comparison - use moneyMinus")
   }
 
   /**
@@ -188,7 +188,7 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return (Money, Money)
    */
   def /%(that: BigDecimal): (Money, Money) = amount /% that match {
-    case (q, r) ⇒ (new Money(q)(currency), new Money(r)(currency))
+    case (q, r) => (new Money(q)(currency), new Money(r)(currency))
   }
 
   /**
@@ -225,8 +225,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return Double
    */
   override def divide(that: Money): Double = that.currency match {
-    case this.currency ⇒ (this.amount / that.amount).toDouble
-    case _             ⇒ throw new UnsupportedOperationException("divide not supported for cross-currency comparison - use moneyDivide")
+    case this.currency => (this.amount / that.amount).toDouble
+    case _             => throw new UnsupportedOperationException("divide not supported for cross-currency comparison - use moneyDivide")
   }
 
   /**
@@ -235,8 +235,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return Int
    */
   override def max(that: Money): Money = (that, that.currency) match {
-    case (m: Money, this.currency) ⇒ new Money(amount.max(m.amount))(currency)
-    case _                         ⇒ throw new UnsupportedOperationException("max not supported for cross-currency comparison - use moneyMax")
+    case (m: Money, this.currency) => new Money(amount.max(m.amount))(currency)
+    case _                         => throw new UnsupportedOperationException("max not supported for cross-currency comparison - use moneyMax")
   }
 
   /**
@@ -245,8 +245,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return Int
    */
   override def min(that: Money): Money = (that, that.currency) match {
-    case (m: Money, this.currency) ⇒ new Money(amount.min(m.amount))(currency)
-    case _                         ⇒ throw new UnsupportedOperationException("min not supported for cross-currency comparison - use moneyMin")
+    case (m: Money, this.currency) => new Money(amount.min(m.amount))(currency)
+    case _                         => throw new UnsupportedOperationException("min not supported for cross-currency comparison - use moneyMin")
   }
 
   /**
@@ -255,8 +255,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return
    */
   override def equals(that: Any): Boolean = that match {
-    case m: Money ⇒ amount == m.amount && currency == m.currency
-    case _        ⇒ false
+    case m: Money => amount == m.amount && currency == m.currency
+    case _        => false
   }
 
   /**
@@ -271,8 +271,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return Int
    */
   override def compare(that: Money): Int = that.currency match {
-    case this.currency ⇒ if (this.amount > that.amount) 1 else if (this.amount < that.amount) -1 else 0
-    case _             ⇒ throw new UnsupportedOperationException("Comparison between Moneys of dislike Currency is not supported")
+    case this.currency => if (this.amount > that.amount) 1 else if (this.amount < that.amount) -1 else 0
+    case _             => throw new UnsupportedOperationException("Comparison between Moneys of dislike Currency is not supported")
   }
 
   /**
@@ -282,8 +282,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return
    */
   def moneyMax(that: Money)(implicit moneyContext: MoneyContext) = moneyContext.compare(this, that) match {
-    case -1 ⇒ that
-    case _  ⇒ this
+    case -1 => that
+    case _  => this
   }
 
   /**
@@ -293,8 +293,8 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @return
    */
   def moneyMin(that: Money)(implicit moneyContext: MoneyContext) = moneyContext.compare(this, that) match {
-    case 1 ⇒ that
-    case _ ⇒ this
+    case 1 => that
+    case _ => this
   }
 
   /**
@@ -340,14 +340,14 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
    * @throws scala.IllegalArgumentException if the that.currency matches this.currency
    */
   def toThe(that: Money) = that.currency match {
-    case this.currency ⇒ throw new IllegalArgumentException("Can not create Exchange Rate on matching currencies")
-    case _             ⇒ CurrencyExchangeRate(that, this)
+    case this.currency => throw new IllegalArgumentException("Can not create Exchange Rate on matching currencies")
+    case _             => CurrencyExchangeRate(that, this)
   }
 
   /**
    * toThe
    */
-  def -> = toThe _
+  def -> = toThe
 
   /**
    * Convert this Money to a Double representing the currency unit
@@ -407,8 +407,8 @@ object Money extends Dimension[Money] {
   def apply(s: String)(implicit fxContext: MoneyContext): Try[Money] = {
     val regex = ("([-+]?[0-9]*\\.?[0-9]+) *(" + fxContext.currencies.map(_.code).reduceLeft(_ + "|" + _) + ")").r
     s match {
-      case regex(value, currency) ⇒ Currency(currency).map(Money(BigDecimal(value), _))
-      case _                      ⇒ Failure(QuantityParseException("Unable to parse Money", s))
+      case regex(value, currency) => Currency(currency).map(Money(BigDecimal(value), _))
+      case _                      => Failure(QuantityParseException("Unable to parse Money", s))
     }
   }
   def name = "Money"
@@ -429,9 +429,9 @@ object Money extends Dimension[Money] {
 abstract class Currency(val code: String, val name: String, val symbol: String, val formatDecimals: Int) extends UnitOfMeasure[Money] {
   def apply(d: BigDecimal): Money = Money(d, this)
   def apply[A](n: A)(implicit num: Numeric[A]) = Money(BigDecimal(num.toDouble(n)), this)
-  protected def converterFrom: Double ⇒ Double = ???
-  protected def converterTo: Double ⇒ Double = ???
-  def /(that: Money): CurrencyExchangeRate = that toThe Money(1, this)
+  protected def converterFrom: Double => Double = ???
+  protected def converterTo: Double => Double = ???
+  def /(that: Money): CurrencyExchangeRate = that.toThe(Money(1, this))
   override def toString: String = code
 
 
@@ -439,7 +439,7 @@ abstract class Currency(val code: String, val name: String, val symbol: String, 
 
   override def equals(other: Any): Boolean = other match {
     case that: Currency =>
-      (that canEqual this) &&
+      (that.canEqual(this)) &&
         code == that.code &&
         name == that.name &&
         symbol == that.symbol &&

--- a/shared/src/main/scala/squants/market/MoneyContext.scala
+++ b/shared/src/main/scala/squants/market/MoneyContext.scala
@@ -32,7 +32,7 @@ case class MoneyContext(
     rates: Seq[CurrencyExchangeRate],
     allowIndirectConversions: Boolean = true) {
 
-  lazy val currencyMap = currencies.map { (c: Currency) ⇒ c.code -> c }.toMap
+  lazy val currencyMap = currencies.map { (c: Currency) => c.code -> c }.toMap
 
   /**
     * Custom implementation using SortedSets to ensure consistent output
@@ -53,7 +53,7 @@ case class MoneyContext(
    * @return
    */
   def directRateFor(curA: Currency, curB: Currency): Option[CurrencyExchangeRate] = {
-    rates.find(r ⇒
+    rates.find(r =>
       r.base.currency == curA && r.counter.currency == curB ||
         r.base.currency == curB && r.counter.currency == curA)
   }
@@ -72,20 +72,20 @@ case class MoneyContext(
     // TODO Improve this to attempt to use defaultCurrency first
 
     directRateFor(curA, curB) match {
-      case Some(rate) ⇒ Some(rate)
-      case _ ⇒
-        val ratesWithCurA = rates.filter(r ⇒ r.base.currency == curA || r.counter.currency == curA)
-        val ratesWithCurB = rates.filter(r ⇒ r.base.currency == curB || r.counter.currency == curB)
+      case Some(rate) => Some(rate)
+      case _ =>
+        val ratesWithCurA = rates.filter(r => r.base.currency == curA || r.counter.currency == curA)
+        val ratesWithCurB = rates.filter(r => r.base.currency == curB || r.counter.currency == curB)
 
         val curs = for {
-          cur ← currencies
+          cur <- currencies
           if ratesWithCurA.map(_.base.currency).contains(cur) || ratesWithCurA.map(_.counter.currency).contains(cur)
           if ratesWithCurB.map(_.base.currency).contains(cur) || ratesWithCurB.map(_.counter.currency).contains(cur)
         } yield cur
 
         curs.headOption match {
-          case Some(cur) ⇒ Some(CurrencyExchangeRate(convert(cur(1), curA), convert(cur(1), curB)))
-          case None      ⇒ None
+          case Some(cur) => Some(CurrencyExchangeRate(convert(cur(1), curA), convert(cur(1), curB)))
+          case None      => None
         }
     }
   }
@@ -106,12 +106,12 @@ case class MoneyContext(
 
     if (money.currency == currency) money
     else directRateFor(money.currency, currency) match {
-      case Some(rate) ⇒ rate.convert(money)
-      case _ if allowIndirectConversions ⇒ indirectRateFor(money.currency, currency) match {
-        case Some(crossRate) ⇒ crossRate.convert(money)
-        case None            ⇒ throw new NoSuchExchangeRateException(s"Rate for currency pair (${money.currency} / $currency)")
+      case Some(rate) => rate.convert(money)
+      case _ if allowIndirectConversions => indirectRateFor(money.currency, currency) match {
+        case Some(crossRate) => crossRate.convert(money)
+        case None            => throw new NoSuchExchangeRateException(s"Rate for currency pair (${money.currency} / $currency)")
       }
-      case _ ⇒ throw new NoSuchExchangeRateException(s"Rate for currency pair (${money.currency} / $currency)")
+      case _ => throw new NoSuchExchangeRateException(s"Rate for currency pair (${money.currency} / $currency)")
     }
   }
 

--- a/shared/src/main/scala/squants/market/Price.scala
+++ b/shared/src/main/scala/squants/market/Price.scala
@@ -46,7 +46,7 @@ case class Price[A <: Quantity[A]](money: Money, quantity: A) extends Ratio[Mone
   def /(that: Price[A]): BigDecimal = divide(that)
 
   def in(currency: Currency)(implicit moneyContext: MoneyContext) =
-    (money in currency) / quantity
+    (money.in(currency)) / quantity
 
   /**
    * Returns the Cost (Money) for a quantity `that` of A
@@ -68,6 +68,6 @@ case class Price[A <: Quantity[A]](money: Money, quantity: A) extends Ratio[Mone
   def toString(unit: UnitOfMeasure[A]) = money.toString + "/" + quantity.toString(unit)
 
   def toString(currency: Currency, unit: UnitOfMeasure[A])(implicit moneyContext: MoneyContext) =
-    (money in currency).toString + "/" + quantity.toString(unit)
+    (money.in(currency)).toString + "/" + quantity.toString(unit)
 }
 

--- a/shared/src/main/scala/squants/mass/Density.scala
+++ b/shared/src/main/scala/squants/mass/Density.scala
@@ -54,8 +54,8 @@ object Density extends Dimension[Density] {
   def apply(m: Mass, v: Volume): Density = KilogramsPerCubicMeter(m.toKilograms / v.toCubicMeters)
   def apply(value: Any): Try[Density] = parse(value)
   def name = "Density"
-  def primaryUnit: UnitOfMeasure[Density] with PrimaryUnit = KilogramsPerCubicMeter
-  def siUnit: UnitOfMeasure[Density] with SiUnit = KilogramsPerCubicMeter
+  def primaryUnit: UnitOfMeasure[Density] & PrimaryUnit = KilogramsPerCubicMeter
+  def siUnit: UnitOfMeasure[Density] & SiUnit = KilogramsPerCubicMeter
   def units = Set(KilogramsPerCubicMeter,
     KilogramsPerLitre, GramsPerLitre, MilligramsPerLitre, MicrogramsPerLitre, NanogramsPerLitre,
     KilogramsPerMillilitre, GramsPerMillilitre, MilligramsPerMillilitre, MicrogramsPerMillilitre, NanogramsPerMillilitre,

--- a/shared/src/main/scala/squants/mass/Mass.scala
+++ b/shared/src/main/scala/squants/mass/Mass.scala
@@ -12,7 +12,7 @@ import squants.energy.{ Energy, Joules, SpecificEnergy }
 import squants.motion.{ Force, MassFlow, Momentum, _ }
 import squants.space.{ CubicMeters, SquareMeters }
 import squants.time.TimeIntegral
-import squants.{ Acceleration, Energy ⇒ _, Velocity, _ }
+import squants.{ Acceleration, Energy => _, Velocity, _ }
 
 /**
  * Represents a quantity of Mass

--- a/shared/src/main/scala/squants/space/Area.scala
+++ b/shared/src/main/scala/squants/space/Area.scala
@@ -29,11 +29,11 @@ final class Area private (val value: Double, val unit: AreaUnit)
   def dimension = Area
 
   def *(that: Length): Volume = unit match {
-    case SquareUsMiles ⇒ CubicUsMiles(this.value * that.toUsMiles)
-    case SquareYards   ⇒ CubicYards(this.value * that.toYards)
-    case SquareFeet    ⇒ CubicFeet(this.value * that.toFeet)
-    case SquareInches  ⇒ CubicInches(this.value * that.toInches)
-    case _             ⇒ CubicMeters(this.toSquareMeters * that.toMeters)
+    case SquareUsMiles => CubicUsMiles(this.value * that.toUsMiles)
+    case SquareYards   => CubicYards(this.value * that.toYards)
+    case SquareFeet    => CubicFeet(this.value * that.toFeet)
+    case SquareInches  => CubicInches(this.value * that.toInches)
+    case _             => CubicMeters(this.toSquareMeters * that.toMeters)
   }
 
   def *(that: AreaDensity): Mass = Kilograms(this.toSquareMeters * that.toKilogramsPerSquareMeter)
@@ -46,11 +46,11 @@ final class Area private (val value: Double, val unit: AreaUnit)
   def *(that: Time): AreaTime = SquareMeterSeconds(this.toSquareMeters * that.toSeconds)
 
   def /(that: Length): Length = unit match {
-    case SquareUsMiles ⇒ UsMiles(this.value / that.toUsMiles)
-    case SquareYards   ⇒ Yards(this.value / that.toYards)
-    case SquareFeet    ⇒ Feet(this.value / that.toFeet)
-    case SquareInches  ⇒ Inches(this.value / that.toInches)
-    case _             ⇒ Meters(this.toSquareMeters / that.toMeters)
+    case SquareUsMiles => UsMiles(this.value / that.toUsMiles)
+    case SquareYards   => Yards(this.value / that.toYards)
+    case SquareFeet    => Feet(this.value / that.toFeet)
+    case SquareInches  => Inches(this.value / that.toInches)
+    case _             => Meters(this.toSquareMeters / that.toMeters)
   }
 
   def squareRoot = Meters(math.sqrt(toSquareMeters))

--- a/shared/src/main/scala/squants/space/Length.scala
+++ b/shared/src/main/scala/squants/space/Length.scala
@@ -34,20 +34,20 @@ final class Length private (val value: Double, val unit: LengthUnit)
   protected[squants] def time = Seconds(1)
 
   def *(that: Length): Area = unit match {
-    case Centimeters ⇒ SquareCentimeters(this.value * that.toCentimeters)
-    case Kilometers  ⇒ SquareKilometers(this.value * that.toKilometers)
-    case UsMiles     ⇒ SquareUsMiles(this.value * that.toUsMiles)
-    case Yards       ⇒ SquareYards(this.value * that.toYards)
-    case Feet        ⇒ SquareFeet(this.value * that.toFeet)
-    case Inches      ⇒ SquareInches(this.value * that.toInches)
-    case _           ⇒ SquareMeters(toMeters * that.toMeters)
+    case Centimeters => SquareCentimeters(this.value * that.toCentimeters)
+    case Kilometers  => SquareKilometers(this.value * that.toKilometers)
+    case UsMiles     => SquareUsMiles(this.value * that.toUsMiles)
+    case Yards       => SquareYards(this.value * that.toYards)
+    case Feet        => SquareFeet(this.value * that.toFeet)
+    case Inches      => SquareInches(this.value * that.toInches)
+    case _           => SquareMeters(toMeters * that.toMeters)
   }
 
   def *(that: Area): Volume = unit match {
-    case Yards  ⇒ CubicYards(this.value * that.toSquareYards)
-    case Feet   ⇒ CubicFeet(this.value * that.toSquareFeet)
-    case Inches ⇒ CubicInches(this.value * that.toSquareInches)
-    case _      ⇒ CubicMeters(this.toMeters * that.toSquareMeters)
+    case Yards  => CubicYards(this.value * that.toSquareYards)
+    case Feet   => CubicFeet(this.value * that.toSquareFeet)
+    case Inches => CubicInches(this.value * that.toSquareInches)
+    case _      => CubicMeters(this.toMeters * that.toSquareMeters)
   }
 
   def *(that: Force): Energy = Joules(this.toMeters * that.toNewtons)

--- a/shared/src/main/scala/squants/space/Volume.scala
+++ b/shared/src/main/scala/squants/space/Volume.scala
@@ -35,19 +35,19 @@ final class Volume private (val value: Double, val unit: VolumeUnit)
   def *(that: EnergyDensity): Energy = Joules(this.toCubicMeters * that.toJoulesPerCubicMeter)
 
   def /(that: Area): Length = unit match {
-    case CubicUsMiles ⇒ UsMiles(this.value / that.toSquareUsMiles)
-    case CubicYards   ⇒ Yards(this.value / that.toSquareYards)
-    case CubicFeet    ⇒ Feet(this.value / that.toSquareFeet)
-    case CubicInches  ⇒ Inches(this.value / that.toSquareInches)
-    case _            ⇒ Meters(this.toCubicMeters / that.toSquareMeters)
+    case CubicUsMiles => UsMiles(this.value / that.toSquareUsMiles)
+    case CubicYards   => Yards(this.value / that.toSquareYards)
+    case CubicFeet    => Feet(this.value / that.toSquareFeet)
+    case CubicInches  => Inches(this.value / that.toSquareInches)
+    case _            => Meters(this.toCubicMeters / that.toSquareMeters)
   }
 
   def /(that: Length): Area = unit match {
-    case CubicUsMiles ⇒ SquareUsMiles(this.value / that.toUsMiles)
-    case CubicYards   ⇒ SquareYards(this.value / that.toYards)
-    case CubicFeet    ⇒ SquareFeet(this.value / that.toFeet)
-    case CubicInches  ⇒ SquareInches(this.value / that.toInches)
-    case _            ⇒ SquareMeters(this.toCubicMeters / that.toMeters)
+    case CubicUsMiles => SquareUsMiles(this.value / that.toUsMiles)
+    case CubicYards   => SquareYards(this.value / that.toYards)
+    case CubicFeet    => SquareFeet(this.value / that.toFeet)
+    case CubicInches  => SquareInches(this.value / that.toInches)
+    case _            => SquareMeters(this.toCubicMeters / that.toMeters)
   }
 
   def /(that: Mass) = ??? // returns SpecificVolume (inverse of Density)

--- a/shared/src/main/scala/squants/thermal/Temperature.scala
+++ b/shared/src/main/scala/squants/thermal/Temperature.scala
@@ -88,37 +88,37 @@ final class Temperature private (val value: Double, val unit: TemperatureScale)
   def toString(unit: TemperatureScale): String = in(unit).toString
 
   private def convert(toScale: TemperatureScale, withOffset: Boolean = true): Temperature = (unit, toScale, withOffset) match {
-    case (Fahrenheit, Fahrenheit, _)  ⇒ this
-    case (Celsius, Celsius, _)        ⇒ this
-    case (Kelvin, Kelvin, _)          ⇒ this
-    case (Rankine, Rankine, _)        ⇒ this
+    case (Fahrenheit, Fahrenheit, _)  => this
+    case (Celsius, Celsius, _)        => this
+    case (Kelvin, Kelvin, _)          => this
+    case (Rankine, Rankine, _)        => this
 
-    case (Fahrenheit, Celsius, true)  ⇒ Celsius(TemperatureConversions.fahrenheitToCelsiusScale(value))
-    case (Celsius, Fahrenheit, true)  ⇒ Fahrenheit(TemperatureConversions.celsiusToFahrenheitScale(value))
-    case (Celsius, Kelvin, true)      ⇒ Kelvin(TemperatureConversions.celsiusToKelvinScale(value))
-    case (Kelvin, Celsius, true)      ⇒ Celsius(TemperatureConversions.kelvinToCelsiusScale(value))
-    case (Fahrenheit, Kelvin, true)   ⇒ Kelvin(TemperatureConversions.fahrenheitToKelvinScale(value))
-    case (Kelvin, Fahrenheit, true)   ⇒ Fahrenheit(TemperatureConversions.kelvinToFahrenheitScale(value))
-    case (Fahrenheit, Rankine, true)  ⇒ Rankine(TemperatureConversions.fahrenheitToRankineScale(value))
-    case (Rankine, Fahrenheit, true)  ⇒ Fahrenheit(TemperatureConversions.rankineToFahrenheitScale(value))
-    case (Celsius, Rankine, true)     ⇒ Rankine(TemperatureConversions.celsiusToRankineScale(value))
-    case (Rankine, Celsius, true)     ⇒ Celsius(TemperatureConversions.rankineToCelsiusScale(value))
-    case (Kelvin, Rankine, true)      ⇒ Rankine(TemperatureConversions.kelvinToRankineScale(value))
-    case (Rankine, Kelvin, true)      ⇒ Kelvin(TemperatureConversions.rankineToKelvinScale(value))
+    case (Fahrenheit, Celsius, true)  => Celsius(TemperatureConversions.fahrenheitToCelsiusScale(value))
+    case (Celsius, Fahrenheit, true)  => Fahrenheit(TemperatureConversions.celsiusToFahrenheitScale(value))
+    case (Celsius, Kelvin, true)      => Kelvin(TemperatureConversions.celsiusToKelvinScale(value))
+    case (Kelvin, Celsius, true)      => Celsius(TemperatureConversions.kelvinToCelsiusScale(value))
+    case (Fahrenheit, Kelvin, true)   => Kelvin(TemperatureConversions.fahrenheitToKelvinScale(value))
+    case (Kelvin, Fahrenheit, true)   => Fahrenheit(TemperatureConversions.kelvinToFahrenheitScale(value))
+    case (Fahrenheit, Rankine, true)  => Rankine(TemperatureConversions.fahrenheitToRankineScale(value))
+    case (Rankine, Fahrenheit, true)  => Fahrenheit(TemperatureConversions.rankineToFahrenheitScale(value))
+    case (Celsius, Rankine, true)     => Rankine(TemperatureConversions.celsiusToRankineScale(value))
+    case (Rankine, Celsius, true)     => Celsius(TemperatureConversions.rankineToCelsiusScale(value))
+    case (Kelvin, Rankine, true)      => Rankine(TemperatureConversions.kelvinToRankineScale(value))
+    case (Rankine, Kelvin, true)      => Kelvin(TemperatureConversions.rankineToKelvinScale(value))
 
 
-    case (Fahrenheit, Celsius, false) ⇒ Celsius(TemperatureConversions.fahrenheitToCelsiusDegrees(value))
-    case (Celsius, Fahrenheit, false) ⇒ Fahrenheit(TemperatureConversions.celsiusToFahrenheitDegrees(value))
-    case (Celsius, Kelvin, false)     ⇒ Kelvin(TemperatureConversions.celsiusToKelvinDegrees(value))
-    case (Kelvin, Celsius, false)     ⇒ Celsius(TemperatureConversions.kelvinToCelsiusDegrees(value))
-    case (Fahrenheit, Kelvin, false)  ⇒ Kelvin(TemperatureConversions.fahrenheitToKelvinDegrees(value))
-    case (Kelvin, Fahrenheit, false)  ⇒ Fahrenheit(TemperatureConversions.kelvinToFahrenheitDegrees(value))
-    case (Fahrenheit, Rankine, false) ⇒ Rankine(TemperatureConversions.fahrenheitToRankineDegrees(value))
-    case (Rankine, Fahrenheit, false) ⇒ Fahrenheit(TemperatureConversions.rankineToFahrenheitDegrees(value))
-    case (Celsius, Rankine, false)    ⇒ Rankine(TemperatureConversions.celsiusToRankineDegrees(value))
-    case (Rankine, Celsius, false)    ⇒ Celsius(TemperatureConversions.rankineToCelsiusDegrees(value))
-    case (Kelvin, Rankine, false)     ⇒ Rankine(TemperatureConversions.kelvinToRankineDegrees(value))
-    case (Rankine, Kelvin, false)     ⇒ Kelvin(TemperatureConversions.rankineToKelvinDegrees(value))
+    case (Fahrenheit, Celsius, false) => Celsius(TemperatureConversions.fahrenheitToCelsiusDegrees(value))
+    case (Celsius, Fahrenheit, false) => Fahrenheit(TemperatureConversions.celsiusToFahrenheitDegrees(value))
+    case (Celsius, Kelvin, false)     => Kelvin(TemperatureConversions.celsiusToKelvinDegrees(value))
+    case (Kelvin, Celsius, false)     => Celsius(TemperatureConversions.kelvinToCelsiusDegrees(value))
+    case (Fahrenheit, Kelvin, false)  => Kelvin(TemperatureConversions.fahrenheitToKelvinDegrees(value))
+    case (Kelvin, Fahrenheit, false)  => Fahrenheit(TemperatureConversions.kelvinToFahrenheitDegrees(value))
+    case (Fahrenheit, Rankine, false) => Rankine(TemperatureConversions.fahrenheitToRankineDegrees(value))
+    case (Rankine, Fahrenheit, false) => Fahrenheit(TemperatureConversions.rankineToFahrenheitDegrees(value))
+    case (Celsius, Rankine, false)    => Rankine(TemperatureConversions.celsiusToRankineDegrees(value))
+    case (Rankine, Celsius, false)    => Celsius(TemperatureConversions.rankineToCelsiusDegrees(value))
+    case (Kelvin, Rankine, false)     => Rankine(TemperatureConversions.kelvinToRankineDegrees(value))
+    case (Rankine, Kelvin, false)     => Kelvin(TemperatureConversions.rankineToKelvinDegrees(value))
   }
 
   def in(unit: TemperatureScale) = convert(unit, withOffset = true)

--- a/shared/src/main/scala/squants/time/Time.scala
+++ b/shared/src/main/scala/squants/time/Time.scala
@@ -30,7 +30,7 @@ final class Time private (val value: Double, val unit: TimeUnit)
 
   def millis = toMilliseconds.toLong
 
-  def *[A <: squants.Quantity[A] with squants.time.TimeIntegral[_]](that: TimeDerivative[A]): A = that * this
+  def *[A <: squants.Quantity[A] & squants.time.TimeIntegral[?]](that: TimeDerivative[A]): A = that * this
 
   def *(that: Time) = TimeSquared(this, that)
   def squared = TimeSquared(this)
@@ -63,13 +63,13 @@ object Time extends Dimension[Time] with BaseDimension {
   private[time] def apply[A](n: A, unit: TimeUnit)(implicit num: Numeric[A]) = new Time(num.toDouble(n), unit)
   def apply(value: Any) = parse(value)
   def apply(duration: Duration): Time = duration.unit match {
-    case NANOSECONDS  ⇒ Nanoseconds(duration.length)
-    case MICROSECONDS ⇒ Microseconds(duration.length)
-    case MILLISECONDS ⇒ Milliseconds(duration.length)
-    case SECONDS      ⇒ Seconds(duration.length)
-    case MINUTES      ⇒ Minutes(duration.length)
-    case HOURS        ⇒ Hours(duration.length)
-    case DAYS         ⇒ Days(duration.length)
+    case NANOSECONDS  => Nanoseconds(duration.length)
+    case MICROSECONDS => Microseconds(duration.length)
+    case MILLISECONDS => Milliseconds(duration.length)
+    case SECONDS      => Seconds(duration.length)
+    case MINUTES      => Minutes(duration.length)
+    case HOURS        => Hours(duration.length)
+    case DAYS         => Days(duration.length)
   }
 
   def name = "Time"
@@ -152,13 +152,13 @@ object TimeConversions {
    * @return
    */
   implicit def timeToScalaDuration(time: Time): Duration = time.unit match {
-    case Nanoseconds  ⇒ Duration(time.value.toLong, NANOSECONDS)
-    case Microseconds ⇒ Duration(time.value.toLong, MICROSECONDS)
-    case Milliseconds ⇒ Duration(time.value.toLong, MILLISECONDS)
-    case Seconds      ⇒ Duration(time.value.toLong, SECONDS)
-    case Minutes      ⇒ Duration(time.value.toLong, MINUTES)
-    case Hours        ⇒ Duration(time.value.toLong, HOURS)
-    case Days         ⇒ Duration(time.value.toLong, DAYS)
+    case Nanoseconds  => Duration(time.value.toLong, NANOSECONDS)
+    case Microseconds => Duration(time.value.toLong, MICROSECONDS)
+    case Milliseconds => Duration(time.value.toLong, MILLISECONDS)
+    case Seconds      => Duration(time.value.toLong, SECONDS)
+    case Minutes      => Duration(time.value.toLong, MINUTES)
+    case Hours        => Duration(time.value.toLong, HOURS)
+    case Days         => Duration(time.value.toLong, DAYS)
   }
 
   implicit def scalaDurationToTime(duration: Duration): Time = Time(duration)

--- a/shared/src/main/scala/squants/time/TimeDerivative.scala
+++ b/shared/src/main/scala/squants/time/TimeDerivative.scala
@@ -18,7 +18,7 @@ import squants._
  *
  * @tparam A The type of quantity changing
  */
-trait TimeDerivative[A <: Quantity[A] with TimeIntegral[_]] {
+trait TimeDerivative[A <: Quantity[A] & TimeIntegral[?]] {
   protected[squants] def timeIntegrated: A
   protected[squants] def time: Time
 
@@ -39,7 +39,7 @@ trait TimeDerivative[A <: Quantity[A] with TimeIntegral[_]] {
   def /(that: A): Frequency = (timeIntegrated / that) / time
 }
 
-trait SecondTimeDerivative[A <: SecondTimeIntegral[_]] { self: TimeDerivative[_] ⇒
+trait SecondTimeDerivative[A <: SecondTimeIntegral[?]] { self: TimeDerivative[?] =>
   protected[squants] def time: Time
   def *(that: TimeSquared): A
 }
@@ -52,7 +52,7 @@ trait SecondTimeDerivative[A <: SecondTimeIntegral[_]] { self: TimeDerivative[_]
  *
  * @tparam A The Quantity type for the TimeDerivative for which this is the base
  */
-trait TimeIntegral[A <: Quantity[A] with TimeDerivative[_]] {
+trait TimeIntegral[A <: Quantity[A] & TimeDerivative[?]] {
   protected def timeDerived: A
   protected def time: Time
 
@@ -83,7 +83,7 @@ trait TimeIntegral[A <: Quantity[A] with TimeDerivative[_]] {
   def *(that: Frequency): A = /(this.time) * (this.time * that).toEach
 }
 
-trait SecondTimeIntegral[A <: SecondTimeDerivative[_]] { self: TimeIntegral[_] ⇒
+trait SecondTimeIntegral[A <: SecondTimeDerivative[?]] { self: TimeIntegral[?] =>
   def /(that: A): TimeSquared
   def /(that: TimeSquared): A
   def per(that: TimeSquared): A = /(that)

--- a/shared/src/main/scala/squants/time/TimeSquared.scala
+++ b/shared/src/main/scala/squants/time/TimeSquared.scala
@@ -32,7 +32,7 @@ package squants.time
  */
 case class TimeSquared(time1: Time, time2: Time) {
   def squareRoot = time1.unit(math.sqrt(time1.value * time2.to(time1.unit)))
-  def *(that: SecondTimeDerivative[_]) = that * (this.time1 * this.time2)
+  def *(that: SecondTimeDerivative[?]) = that * (this.time1 * this.time2)
 }
 
 object TimeSquared {

--- a/shared/src/main/tut/README.md
+++ b/shared/src/main/tut/README.md
@@ -1110,7 +1110,7 @@ class ScadaLoadListener(router: Router) extends Actor {
   def receive = {
    // ScadaLoadReading - from an external service - sends load as a string
    // eg, “10.3 MW”, “345 kW”
-   case msg @ ScadaLoadReading(meterId, time, loadString) ⇒
+   case msg @ ScadaLoadReading(meterId, time, loadString) =>
     // Parse the string and on success emit the Squants enabled event to routees
     Power(loadString) match {
       case Success(p) => router.route(LoadReading(meterId, time, p), sender())

--- a/shared/src/test/BradyBudget.sc
+++ b/shared/src/test/BradyBudget.sc
@@ -37,7 +37,7 @@ val weeklyMilkBudget = milkPrice * usageInOneWeek
 // Display Results
 println("Brady Bunch Milk Budget")
 val format = "%.2f"
-theBradyBunch.map(b ⇒ s"${b.name} - ${b.milkConsumption.toString(GallonsPerDay, format)}").foreach(println)
+theBradyBunch.map(b => s"${b.name} - ${b.milkConsumption.toString(GallonsPerDay, format)}").foreach(println)
 println(s"      Milk Price: ${milkPrice.toString(UsGallons)}")
 println(s" Total Milk Flow: ${totalMilkConsumption.toString(GallonsPerDay, format)}")
 println(s" Usage in 1 week: ${usageInOneWeek.toString(UsGallons, format)}")

--- a/shared/src/test/scala/squants/CustomMatchers.scala
+++ b/shared/src/test/scala/squants/CustomMatchers.scala
@@ -29,14 +29,14 @@ trait CustomMatchers {
       extends Matcher[A] {
     def apply(left: A) = {
       MatchResult(
-        left approx expectedValue,
+        left.approx(expectedValue),
         s"$left was not approximately equal to $expectedValue ($tolerance)",
         s"$left was approximately equal to $expectedValue ($tolerance)")
     }
   }
 
   def beApproximately[A <: Quantity[A]](expectedValue: A)(implicit tolerance: A) =
-    new QuantityApproximatelyEqualTo(expectedValue)(tolerance)
+    new QuantityApproximatelyEqualTo(expectedValue)(using tolerance)
 
   class DoubleApproximatelyEqualTo(expectedValue: Double)(implicit tolerance: Double)
       extends Matcher[Double] {

--- a/shared/src/test/scala/squants/QuantityRangeSpec.scala
+++ b/shared/src/test/scala/squants/QuantityRangeSpec.scala
@@ -41,7 +41,7 @@ class QuantityRangeSpec extends AnyFlatSpec with Matchers {
 
   it should "times a Double and get back a List of ranges" in {
     val r = QuantityRange(Meters(0), Meters(10))
-    val rs = r times 3
+    val rs = r.times(3)
     rs.head should be(QuantityRange(Meters(0), Meters(10)))
     rs.tail.head should be(QuantityRange(Meters(10), Meters(20)))
     rs.tail.tail.head should be(QuantityRange(Meters(20), Meters(30)))
@@ -71,52 +71,52 @@ class QuantityRangeSpec extends AnyFlatSpec with Matchers {
   it should "foreach a like value and execute an operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(5))
     var accum = 0d
-    r.foreach(Meters(1))(sub ⇒ accum = accum + sub.upper.toMeters)
+    r.foreach(Meters(1))(sub => accum = accum + sub.upper.toMeters)
     accum should be(15)
   }
 
   it should "foreach a Double and execute an operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(5))
     var accum = 0d
-    r.foreach(5)(sub ⇒ accum = accum + sub.upper.toMeters)
+    r.foreach(5)(sub => accum = accum + sub.upper.toMeters)
     accum should be(15)
   }
 
   it should "map a like value and applies a map operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(5))
     val rs = r / Meters(1)
-    val rsMapped = r.map(Meters(1))(x ⇒ x)
+    val rsMapped = r.map(Meters(1))(x => x)
     rsMapped should be(rs)
   }
 
   it should "map a Double and applies a map operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(35))
     val rs = r / 5
-    val rsMapped = r.map(5)(x ⇒ x)
+    val rsMapped = r.map(5)(x => x)
     rsMapped should be(rs)
   }
 
   it should "foldLeft a like value and applies an operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(5))
-    val total = r.foldLeft(Meters(1), Meters(0))((z, x) ⇒ z + x.upper)
+    val total = r.foldLeft(Meters(1), Meters(0))((z, x) => z + x.upper)
     total should be(Meters(15))
   }
 
   it should "foldLeft a Double and applies an operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(5))
-    val total = r.foldLeft(5, Meters(0))((z, x) ⇒ z + x.upper)
+    val total = r.foldLeft(5, Meters(0))((z, x) => z + x.upper)
     total should be(Meters(15))
   }
 
   it should "foldRight a like value and applies an operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(5))
-    val total = r.foldRight(Meters(1), Meters(0))((x, z) ⇒ z + x.upper)
+    val total = r.foldRight(Meters(1), Meters(0))((x, z) => z + x.upper)
     total should be(Meters(15))
   }
 
   it should "foldRight a Double and applies an operation on each sub range" in {
     val r = QuantityRange(Meters(0), Meters(5))
-    val total = r.foldRight(5, Meters(0))((x, z) ⇒ z + x.upper)
+    val total = r.foldRight(5, Meters(0))((x, z) => z + x.upper)
     total should be(Meters(15))
   }
 

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -182,7 +182,7 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
     implicit val tol: Thingee = Thangs(.1)
     val x = Kilothangs(2.0)
     val y = Kilothangs(1.9999)
-    x approx y should be(right = true)
+    x.approx(y) should be(right = true)
     x =~ y should be(right = true)
     x ≈ y should be(right = true)
     (x ~= y) should be(right = true)
@@ -192,7 +192,7 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
     implicit val tol: Thingee = Thangs(.1)
     val x = Kilothangs(2.0)
     val y = Kilothangs(1.9998)
-    x approx y should be(right = false)
+    x.approx(y) should be(right = false)
     x =~ y should be(right = false)
     (x ~= y) should be(right = false)
   }
@@ -201,89 +201,89 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
     implicit val tol: Thingee = Thangs(.1)
     val x = Kilothangs(2.0)
     val y = Kilothangs(1.9999)
-    x approx y should be(right = true)
+    x.approx(y) should be(right = true)
     x =~ y should be(right = true)
     (x ~= y) should be(right = true)
     // apply approx with an explicit override of the tolerance
-    x.approx(y)(Thangs(.01)) should be(right = false)
-    x.=~(y)(Thangs(.01)) should be(right = false)
-    x.~=(y)(Thangs(.01)) should be(right = false)
+    x.approx(y)(using Thangs(.01)) should be(right = false)
+    x.=~(y)(using Thangs(.01)) should be(right = false)
+    x.~=(y)(using Thangs(.01)) should be(right = false)
   }
 
   it should "add two like values and result in a like value" in {
     val x = Thangs(14.999)
     val y = Thangs(0.001)
-    x plus y should be(Thangs(15))
+    x.plus(y) should be(Thangs(15))
     x + y should be(Thangs(15))
   }
 
   it should "add two like value in different units and result in a like value" in {
     val x = Kilothangs(14.999)
     val y = Thangs(1)
-    x plus y should be(Kilothangs(15))
+    x.plus(y) should be(Kilothangs(15))
     x + y should be(Kilothangs(15))
   }
 
   it should "minus two like values and result in a like value" in {
     val x = Thangs(15.0)
     val y = Thangs(0.001)
-    (x minus y) should be(Thangs(14.999))
+    (x.minus(y)) should be(Thangs(14.999))
     x - y should be(Thangs(14.999))
   }
 
   it should "minus two like value in different units and result in a like value" in {
     val x = Kilothangs(15)
     val y = Thangs(1)
-    x minus y should be(Kilothangs(14.999))
+    x.minus(y) should be(Kilothangs(14.999))
     x - y should be(Kilothangs(14.999))
   }
 
   it should "times by a Double and result in a like value" in {
     val x = Thangs(4.5)
     val y = 2.0
-    (x times y) should be(Thangs(9.0))
+    (x.times(y)) should be(Thangs(9.0))
     x * y should be(Thangs(9.0))
   }
 
   it should "divide by a Double and result in a like value" in {
     val x = Thangs(9.0)
     val y = 2.0
-    (x divide y) should be(Thangs(4.5))
+    (x.divide(y)) should be(Thangs(4.5))
     x / y should be(Thangs(4.5))
   }
 
   it should "divide by a like value and result in a Double" in {
     val x = Thangs(9.0)
     val y = Thangs(2.0)
-    (x divide y) should be(4.5)
+    (x.divide(y)) should be(4.5)
     x / y should be(4.5)
   }
 
   it should "divide by a like value in different units and result in a Double" in {
     val x = Kilothangs(9)
     val y = Thangs(2)
-    x divide y should be(4500.0)
+    x.divide(y) should be(4500.0)
     x / y should be(4500.0)
   }
 
   it should "remainder by a Double and result in a like value" in {
     val x = Thangs(9.0)
     val y = 2.0
-    x remainder y should be(Thangs(1))
+    x.remainder(y) should be(Thangs(1))
     x % y should be(Thangs(1))
   }
 
   it should "remainder by a like value and result in a Double" in {
     val x = Thangs(9.0)
     val y = Thangs(2.0)
-    (x remainder y) should be(1.0)
+    (x.remainder(y)) should be(1.0)
     x % y should be(1.0)
   }
 
   it should "divideAndRemainder by a Double and result in a pair of like values" in {
     val x = Thangs(9.0)
     val y = 2.0
-    val p1 = x divideAndRemainder y
+    val p1 = x.divideAndRemainder(y)
     p1._1 should be(Thangs(4))
     p1._2 should be(Thangs(1))
     val p2 = x /% y
@@ -294,7 +294,7 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
   it should "divideAndRemainder by a like value and result in a Double and like value" in {
     val x = Thangs(9.0)
     val y = Thangs(2.0)
-    val p1 = x divideAndRemainder y
+    val p1 = x.divideAndRemainder(y)
     p1._1 should be(4)
     p1._2 should be(Thangs(1))
     val p2 = x /% y
@@ -413,40 +413,40 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
 
   it should "compare a like value values and return 1, 0, or -1" in {
     val x = Kilothangs(5)
-    (x compare Kilothangs(4.999)) should be(1)
-    (x compare Kilothangs(5)) should be(0)
-    (x compare Kilothangs(5.001)) should be(-1)
+    (x.compare(Kilothangs(4.999))) should be(1)
+    (x.compare(Kilothangs(5))) should be(0)
+    (x.compare(Kilothangs(5.001))) should be(-1)
 
-    (x compare Thangs(4999.0)) should be(1)
-    (x compare Thangs(5000.0)) should be(0)
-    (x compare Thangs(5001.0)) should be(-1)
+    (x.compare(Thangs(4999.0))) should be(1)
+    (x.compare(Thangs(5000.0))) should be(0)
+    (x.compare(Thangs(5001.0))) should be(-1)
   }
 
   it should "max a like value and return the greater of the two" in {
     val x = Thangs(5)
     val y = Thangs(4.999)
-    (x max y) should be(Thangs(5))
+    (x.max(y)) should be(Thangs(5))
 
-    (x max y) should be(Thangs(5))
+    (x.max(y)) should be(Thangs(5))
   }
 
   it should "min a like value and return the greater of the two" in {
     val x = Thangs(5)
     val y = Thangs(4.999)
-    (x min y) should be(Thangs(4.999))
+    (x.min(y)) should be(Thangs(4.999))
   }
 
   it should "plusOrMinus a like value and return a QuantityRange" in {
     val x = Thangs(5)
     val y = Thangs(1)
-    (x plusOrMinus y) should be(QuantityRange(Thangs(4), Thangs(6)))
+    (x.plusOrMinus(y)) should be(QuantityRange(Thangs(4), Thangs(6)))
     x +- y should be(QuantityRange(Thangs(4), Thangs(6)))
   }
 
   it should "to a like value and return a QuantityRange" in {
     val x = Thangs(5)
     val y = Thangs(10)
-    val r = x to y
+    val r = x.to(y)
     r should be(QuantityRange(x, y))
   }
 
@@ -457,8 +457,8 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
     x.within(r) should be(right = true)
     y.within(r) should be(right = false)
 
-    Thangs(10) within (Thangs(9) +- Thangs(2)) should be(right = true)
-    Thangs(10) within (Thangs(9) to Thangs(12)) should be(right = true)
+    Thangs(10).within((Thangs(9) +- Thangs(2))) should be(right = true)
+    Thangs(10).within((Thangs(9).to(Thangs(12)))) should be(right = true)
   }
 
   it should "notWithin a QuantityRange and return a Boolean" in {
@@ -468,23 +468,23 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
     !x.notWithin(r) should be(right = true)
     y.notWithin(r) should be(right = true)
 
-    Thangs(13) notWithin (Thangs(9) +- Thangs(2)) should be(right = true)
-    Thangs(13) notWithin (Thangs(9) to Thangs(12)) should be(right = true)
+    Thangs(13).notWithin((Thangs(9) +- Thangs(2))) should be(right = true)
+    Thangs(13).notWithin((Thangs(9).to(Thangs(12)))) should be(right = true)
   }
 
   it should "to a unit and return a Double" in {
     val x = Thangs(1500)
-    (x to Kilothangs) should be(1.5)
+    (x.to(Kilothangs)) should be(1.5)
     x.toKilothangs should be(1.5)
   }
 
   it should "in a unit and return a like value in that unit" in {
     // The `in` method is only useful for Quantities that implement quantity classes for each unit
     val x = Fahrenheit(212)
-    (x in Celsius) should be(Celsius(100))
+    (x.in(Celsius)) should be(Celsius(100))
 
     val y = Seconds(3600)
-    (y in Hours) should be(Hours(1))
+    (y.in(Hours)) should be(Hours(1))
   }
 
   it should "toString and return a string formatted for the valueUnit" in {
@@ -494,7 +494,7 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
 
   it should "toString a unit and return a string formatted for the unit" in {
     val x = Thangs(1500)
-    (x toString Kilothangs) should be("1.5 kth")
+    (x.toString(Kilothangs)) should be("1.5 kth")
   }
 
   it should "toString a format and unit and return a string using the format and unit" in {
@@ -521,12 +521,12 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
   it should "return the correct Numeric value when pattern matched against a Unit of Measure" in {
     val x = Thangs(1200)
     val thangs = x match {
-      case Thangs(v) ⇒ v
+      case Thangs(v) => v
     }
     thangs should be(1200)
 
     val kilothangs = x match {
-      case Kilothangs(v) ⇒ v
+      case Kilothangs(v) => v
     }
     kilothangs should be(1.2)
   }
@@ -536,16 +536,16 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
   it should "multiply by a Quantity value and return the product as a like value" in {
     val l = 10.22 * Thangs(1000)
     l.getClass should be(classOf[Thingee])
-    (l to Thangs) should be(10220)
+    (l.to(Thangs)) should be(10220)
 
     val m = 10D * Kilograms(50)
     m.getClass should be(classOf[Mass])
-    (m to Kilograms) should be(500)
+    (m.to(Kilograms)) should be(500)
   }
 
   it should "divide by a Time value and return a Frequency" in {
     10D / Seconds(1) should be(Hertz(10))
-    10D per Seconds(1) should be(Hertz(10))
+    10D.per(Seconds(1)) should be(Hertz(10))
   }
 
   behavior of "SquantifiedLong"
@@ -553,16 +553,16 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
   it should "multiply by a Quantity value and return the product as a like value" in {
     val l = 10L * Thangs(1000)
     l.getClass should be(classOf[Thingee])
-    (l to Thangs) should be(10000)
+    (l.to(Thangs)) should be(10000)
 
     val m = 10L * Kilograms(50)
     m.getClass should be(classOf[Mass])
-    (m to Kilograms) should be(500)
+    (m.to(Kilograms)) should be(500)
   }
 
   it should "divide by a Time value and return a Frequency" in {
     10L / Seconds(1) should be(Hertz(10))
-    10L per Seconds(1) should be(Hertz(10))
+    10L.per(Seconds(1)) should be(Hertz(10))
   }
 
   behavior of "SquantifiedBigDecimal"
@@ -572,16 +572,16 @@ class QuantitySpec extends AnyFlatSpec with Matchers with CustomMatchers with Tr
 
     val l = multiple * Thangs(1000)
     l.getClass should be(classOf[Thingee])
-    (l to Thangs) should be(10000)
+    (l.to(Thangs)) should be(10000)
 
     val m = multiple * Kilograms(50)
     m.getClass should be(classOf[Mass])
-    (m to Kilograms) should be(500)
+    (m.to(Kilograms)) should be(500)
   }
 
   it should "divide by a Time value and return a Frequency" in {
     BigDecimal(10) / Seconds(1) should be(Hertz(10))
-    BigDecimal(10) per Seconds(1) should be(Hertz(10))
+    BigDecimal(10).per(Seconds(1)) should be(Hertz(10))
   }
 
   behavior of "QuantityNumeric"

--- a/shared/src/test/scala/squants/SVectorSpec.scala
+++ b/shared/src/test/scala/squants/SVectorSpec.scala
@@ -130,7 +130,7 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
   it should "dot product with a QuantityVector" in {
     val dVector = SVector(1, 2, 3)
     val qVector = SVector(Meters(1), Meters(2), Meters(3))
-    dVector dotProduct qVector should be(qVector dotProduct dVector)
+    dVector.dotProduct(qVector) should be(qVector.dotProduct(dVector))
   }
 
   it should "cross product with a DoubleVector (with 3 coordinates each)" in {
@@ -144,8 +144,8 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
 
     val up = SVector(1, 2, 3)
     val left = SVector(3, 2, 1)
-    val forward = up crossProduct left
-    val back = left crossProduct up
+    val forward = up.crossProduct(left)
+    val back = left.crossProduct(up)
 
     forward should be (DoubleVector(-4.0, 8.0, -4.0))
     back should be (DoubleVector(4.0, -8.0, 4.0))
@@ -154,14 +154,14 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
   it should "crossProduct with a QuantityVector" in {
     val dVector = SVector(1, 2, 3)
     val qVector = SVector(Meters(1), Meters(2), Meters(3))
-    dVector crossProduct qVector should be(qVector crossProduct dVector)
+    dVector.crossProduct(qVector) should be(qVector.crossProduct(dVector))
   }
 
   it should "throw an exception on crossProduct two Vectors with 7 dimensions" in {
     val v1 = SVector(1, 2, 3, 4, 5, 6, 7)
     val v2 = SVector(1, 2, 3, 4, 5, 6, 7)
     intercept[UnsupportedOperationException] {
-      v1 crossProduct v2
+      v1.crossProduct(v2)
     }
   }
 
@@ -171,21 +171,21 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
     val vector7 = SVector(1, 2, 3, 5, 6, 7)
 
     intercept[UnsupportedOperationException] {
-      vector3 crossProduct vector4
+      vector3.crossProduct(vector4)
     }
     intercept[UnsupportedOperationException] {
-      vector4 crossProduct vector3
-    }
-
-    intercept[UnsupportedOperationException] {
-      vector4 crossProduct vector4
+      vector4.crossProduct(vector3)
     }
 
     intercept[UnsupportedOperationException] {
-      vector7 crossProduct vector4
+      vector4.crossProduct(vector4)
+    }
+
+    intercept[UnsupportedOperationException] {
+      vector7.crossProduct(vector4)
     }
     intercept[UnsupportedOperationException] {
-      vector4 crossProduct vector7
+      vector4.crossProduct(vector7)
     }
   }
 
@@ -260,7 +260,7 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
     val y = Kilometers(2)
     val z = Kilometers(3)
     val quantityVector = SVector(x, y, z)
-    quantityVector.map[Area](l ⇒ l * l).equals(SVector(SquareKilometers(1), SquareKilometers(4), SquareKilometers(9))) should be(right = true)
+    quantityVector.map[Area](l => l * l).equals(SVector(SquareKilometers(1), SquareKilometers(4), SquareKilometers(9))) should be(right = true)
     quantityVector.map[Length](_ * 2).equals(SVector(Kilometers(2), Kilometers(4), Kilometers(6))) should be(right = true)
   }
 
@@ -337,8 +337,8 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
 
     val up = SVector(Kilometers(1), Kilometers(2), Kilometers(3))
     val left = SVector(3, 2, 1)
-    val forward = up crossProduct left
-    val back = left crossProduct up
+    val forward = up.crossProduct(left)
+    val back = left.crossProduct(up)
 
     forward should be (QuantityVector(Kilometers(-4), Kilometers(8), Kilometers(-4)))
     back should be (QuantityVector(Kilometers(-4), Kilometers(8), Kilometers(-4)))
@@ -357,8 +357,8 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
 
     val up = SVector(Kilometers(1), Kilometers(2), Kilometers(3))
     val left = SVector(3, 2, 1)
-    val forward = up crossProduct left
-    val back = left crossProduct up
+    val forward = up.crossProduct(left)
+    val back = left.crossProduct(up)
 
     forward should be (QuantityVector(Kilometers(-4), Kilometers(8), Kilometers(-4)))
     back should be (QuantityVector(Kilometers(-4), Kilometers(8), Kilometers(-4)))
@@ -370,7 +370,7 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
     val v1 = SVector[Length](1, 2, 3, 5, 6, 7)
     val v2 = SVector(1, 2, 3, 5, 6, 7)
     intercept[UnsupportedOperationException] {
-      v1 crossProduct v2
+      v1.crossProduct(v2)
     }
   }
 
@@ -386,38 +386,38 @@ class SVectorSpec extends AnyFlatSpec with Matchers {
 
     // No crossProduct 3D with other sized vectors
     intercept[UnsupportedOperationException] {
-      qv3 crossProduct dv7
+      qv3.crossProduct(dv7)
     }
     intercept[UnsupportedOperationException] {
-      qv3 crossProduct dv4
+      qv3.crossProduct(dv4)
     }
     intercept[UnsupportedOperationException] {
-      dv7 crossProduct qv3
+      dv7.crossProduct(qv3)
     }
     intercept[UnsupportedOperationException] {
-      dv4 crossProduct qv3
+      dv4.crossProduct(qv3)
     }
 
     // NO crossProduct 7D with other sized vectors
     intercept[UnsupportedOperationException] {
-      qv7 crossProduct dv3
+      qv7.crossProduct(dv3)
     }
     intercept[UnsupportedOperationException] {
-      qv7 crossProduct dv4
+      qv7.crossProduct(dv4)
     }
     intercept[UnsupportedOperationException] {
-      dv3 crossProduct qv7
+      dv3.crossProduct(qv7)
     }
     intercept[UnsupportedOperationException] {
-      dv4 crossProduct qv7
+      dv4.crossProduct(qv7)
     }
 
     // No crossProduct with other matching size vectors
     intercept[UnsupportedOperationException] {
-      dv4 crossProduct qv4
+      dv4.crossProduct(qv4)
     }
     intercept[UnsupportedOperationException] {
-      qv4 crossProduct dv4
+      qv4.crossProduct(dv4)
     }
   }
 

--- a/shared/src/test/scala/squants/electro/ElectroChecks.scala
+++ b/shared/src/test/scala/squants/electro/ElectroChecks.scala
@@ -29,87 +29,87 @@ object ElectroChecks extends Properties("Electro") with QuantityChecks {
   implicit val tolPotentional: ElectricPotential = Volts(tol)
   implicit val tolEnergy: Energy = Joules(1e-12)
 
-  property("Volts = Amps * Ohms (Ohm's Law)") = forAll(posNum, posNum) { (amps: TestData, ohms: TestData) ⇒
+  property("Volts = Amps * Ohms (Ohm's Law)") = forAll(posNum, posNum) { (amps: TestData, ohms: TestData) =>
     Volts(amps * ohms) == Amperes(amps) * Ohms(ohms) &&
       Volts(amps * ohms) == Ohms(ohms) * Amperes(amps) &&
       Amperes(amps) == Volts(amps * ohms) / Ohms(ohms) &&
       Ohms(ohms) == Volts(amps * ohms) / Amperes(amps)
   }
 
-  property("Watts = Volts * Amps") = forAll(posNum, posNum) { (volts: TestData, amps: TestData) ⇒
+  property("Watts = Volts * Amps") = forAll(posNum, posNum) { (volts: TestData, amps: TestData) =>
     Watts(volts * amps) == Volts(volts) * Amperes(amps) &&
       Watts(volts * amps) == Amperes(amps) * Volts(volts) &&
       Volts(volts) == Watts(volts * amps) / Amperes(amps) &&
       Amperes(amps) == Watts(volts * amps) / Volts(volts)
   }
 
-  property("Coulombs = Amps * Seconds") = forAll(posNum, posNum) { (amps: TestData, seconds: TestData) ⇒
+  property("Coulombs = Amps * Seconds") = forAll(posNum, posNum) { (amps: TestData, seconds: TestData) =>
     Coulombs(amps * seconds) == Amperes(amps) * Seconds(seconds) &&
       Coulombs(amps * seconds) == Seconds(seconds) * Amperes(amps) &&
       Amperes(amps) =~ Coulombs(amps * seconds) / Seconds(seconds) &&
       Seconds(seconds) =~ Coulombs(amps * seconds) / Amperes(amps)
   }
 
-  property("Coulombs = Farads * Volts") = forAll(posNum, posNum) { (farads: TestData, volts: TestData) ⇒
+  property("Coulombs = Farads * Volts") = forAll(posNum, posNum) { (farads: TestData, volts: TestData) =>
     Coulombs(farads * volts) == Farads(farads) * Volts(volts) &&
       Coulombs(farads * volts) == Volts(volts) * Farads(farads) &&
       Farads(farads) == Coulombs(farads * volts) / Volts(volts) &&
       Volts(volts) == Coulombs(farads * volts) / Farads(farads)
   }
 
-  property("Joules = Newtons * Meters") = forAll(posNum, posNum) { (newtons: TestData, meters: TestData) ⇒
+  property("Joules = Newtons * Meters") = forAll(posNum, posNum) { (newtons: TestData, meters: TestData) =>
     Joules(newtons * meters) =~ Newtons(newtons) * Meters(meters) &&
       Joules(newtons * meters) =~ Meters(meters) * Newtons(newtons) &&
       Newtons(newtons).plusOrMinus(Newtons(tol)).contains(Joules(newtons * meters) / Meters(meters)) &&
       Meters(meters).plusOrMinus(Meters(tol)).contains(Joules(newtons * meters) / Newtons(newtons))
   }
 
-  property("Joules = Kilograms * Grays") = forAll(posNum, posNum) { (kilograms: TestData, grays: TestData) ⇒
+  property("Joules = Kilograms * Grays") = forAll(posNum, posNum) { (kilograms: TestData, grays: TestData) =>
     Joules(kilograms * grays) =~ Kilograms(kilograms) * Grays(grays) &&
       Joules(kilograms * grays) =~ Grays(grays) * Kilograms(kilograms) &&
       Kilograms(kilograms).plusOrMinus(Kilograms(tol)).contains(Joules(kilograms * grays) / Grays(grays)) &&
       Grays(grays).plusOrMinus(Grays(tol)).contains(Joules(kilograms * grays) / Kilograms(kilograms))
   }
 
-  property("Siemens = SiemensPerMeter * Meters") = forAll(posNum, posNum) { (conductivity: TestData, length: TestData) ⇒
+  property("Siemens = SiemensPerMeter * Meters") = forAll(posNum, posNum) { (conductivity: TestData, length: TestData) =>
     Siemens(conductivity * length) == SiemensPerMeter(conductivity) * Meters(length) &&
       Siemens(conductivity * length) == Meters(length) * SiemensPerMeter(conductivity) &&
       Meters(length) == Siemens(conductivity * length) / SiemensPerMeter(conductivity) &&
       SiemensPerMeter(conductivity) == Siemens(conductivity * length) / Meters(length)
   }
 
-  property("OhmMeters = Ohms * Meters") = forAll(posNum, posNum) { (ohms: TestData, meters: TestData) ⇒
+  property("OhmMeters = Ohms * Meters") = forAll(posNum, posNum) { (ohms: TestData, meters: TestData) =>
     OhmMeters(ohms * meters) == Ohms(ohms) * Meters(meters) &&
       OhmMeters(ohms * meters) == Meters(meters) * Ohms(ohms) &&
       Meters(meters) == OhmMeters(ohms * meters) / Ohms(ohms) &&
       Ohms(ohms) == OhmMeters(ohms * meters) / Meters(meters)
   }
 
-  property("Ohms = 1 / Siemens") = forAll(posNum) { (ohms: TestData) ⇒
+  property("Ohms = 1 / Siemens") = forAll(posNum) { (ohms: TestData) =>
     Ohms(ohms).inSiemens.plusOrMinus(Siemens(tol)).contains(Siemens(1.0 / ohms)) &&
       Siemens(1.0 / ohms).inOhms.plusOrMinus(Ohms(tol)).contains(Ohms(ohms))
   }
 
-  property("OhmMeters = 1 / SiemensPerMeter") = forAll(posNum) { (ohmMeters: TestData) ⇒
+  property("OhmMeters = 1 / SiemensPerMeter") = forAll(posNum) { (ohmMeters: TestData) =>
     OhmMeters(ohmMeters).inSiemensPerMeter.plusOrMinus(SiemensPerMeter(tol)).contains(SiemensPerMeter(1.0 / ohmMeters)) &&
       SiemensPerMeter(1.0 / ohmMeters).inOhmMeters.plusOrMinus(OhmMeters(tol)).contains(OhmMeters(ohmMeters))
   }
 
-  property("Webers = Henrys * Amperes") = forAll(posNum, posNum) { (henry: TestData, amps: TestData) ⇒
+  property("Webers = Henrys * Amperes") = forAll(posNum, posNum) { (henry: TestData, amps: TestData) =>
     Webers(henry * amps) == Henry(henry) * Amperes(amps) &&
       Webers(henry * amps) == Amperes(amps) * Henry(henry) &&
       Amperes(amps) == Webers(henry * amps) / Henry(henry) &&
       Henry(henry) == Webers(henry * amps) / Amperes(amps)
   }
 
-  property("Webers = Volts * Seconds") = forAll(posNum, posNum) { (volts: TestData, seconds: TestData) ⇒
+  property("Webers = Volts * Seconds") = forAll(posNum, posNum) { (volts: TestData, seconds: TestData) =>
     Webers(volts * seconds) == Volts(volts) * Seconds(seconds) &&
       Webers(volts * seconds) == Seconds(seconds) * Volts(volts) &&
       Seconds(seconds) =~ Webers(volts * seconds) / Volts(volts) &&
       Volts(volts) =~ Webers(volts * seconds) / Seconds(seconds)
   }
 
-  property("Webers = Teslas * SquareMeters") = forAll(posNum, posNum) { (teslas: TestData, sqMeters: TestData) ⇒
+  property("Webers = Teslas * SquareMeters") = forAll(posNum, posNum) { (teslas: TestData, sqMeters: TestData) =>
     Webers(teslas * sqMeters) == Teslas(teslas) * SquareMeters(sqMeters) &&
       Webers(teslas * sqMeters) == SquareMeters(sqMeters) * Teslas(teslas) &&
       SquareMeters(sqMeters) == Webers(teslas * sqMeters) / Teslas(teslas) &&

--- a/shared/src/test/scala/squants/energy/EnergyChecks.scala
+++ b/shared/src/test/scala/squants/energy/EnergyChecks.scala
@@ -45,56 +45,56 @@ object EnergyChecks extends Properties("Energy") with QuantityChecks {
   implicit val tolThermalCap: ThermalCapacity = JoulesPerKelvin(tol)
   implicit val tolElectricPotential: ElectricPotential = Volts(tol)
 
-  property("WattHours = Watts * Hours") = forAll(posNum, posNum) { (watts: TestData, hours: TestData) ⇒
+  property("WattHours = Watts * Hours") = forAll(posNum, posNum) { (watts: TestData, hours: TestData) =>
     WattHours(watts * hours) == Watts(watts) * Hours(hours) &&
       WattHours(watts * hours) == Hours(hours) * Watts(watts) &&
       Hours(hours) =~ WattHours(watts * hours) / Watts(watts) &&
       Watts(watts) =~ WattHours(watts * hours) / Hours(hours)
   }
 
-  property("Watts = WattsPerHour * Hours") = forAll(posNum, posNum) { (wattsPerHour: TestData, hours: TestData) ⇒
+  property("Watts = WattsPerHour * Hours") = forAll(posNum, posNum) { (wattsPerHour: TestData, hours: TestData) =>
     Watts(wattsPerHour * hours) == WattsPerHour(wattsPerHour) * Hours(hours) &&
       Watts(wattsPerHour * hours) == Hours(hours) * WattsPerHour(wattsPerHour) &&
       Hours(hours) =~ Watts(wattsPerHour * hours) / WattsPerHour(wattsPerHour) &&
       WattsPerHour(wattsPerHour) =~ Watts(wattsPerHour * hours) / Hours(hours)
   }
 
-  property("Watts = Volts * Amps") = forAll(posNum, posNum) { (volts: TestData, amps: TestData) ⇒
+  property("Watts = Volts * Amps") = forAll(posNum, posNum) { (volts: TestData, amps: TestData) =>
     Watts(volts * amps) == Volts(volts) * Amperes(amps) &&
       Watts(volts * amps) == Amperes(amps) * Volts(volts) &&
       Amperes(amps) == Watts(volts * amps) / Volts(volts) &&
       Volts(volts) == Watts(volts * amps) / Amperes(amps)
   }
 
-  property("Joules = Newtons * Meters") = forAll(posNum, posNum) { (newtons: TestData, meters: TestData) ⇒
+  property("Joules = Newtons * Meters") = forAll(posNum, posNum) { (newtons: TestData, meters: TestData) =>
     Joules(newtons * meters) =~ (Newtons(newtons) * Meters(meters)) &&
       Joules(newtons * meters) =~ (Meters(meters) * Newtons(newtons)) &&
       Meters(meters) =~ (Joules(newtons * meters) / Newtons(newtons)) &&
       Newtons(newtons) =~ (Joules(newtons * meters) / Meters(meters))
   }
 
-  property("Joules = Kilograms * Grays") = forAll(posNum, posNum) { (kilograms: TestData, grays: TestData) ⇒
+  property("Joules = Kilograms * Grays") = forAll(posNum, posNum) { (kilograms: TestData, grays: TestData) =>
     Joules(kilograms * grays) =~ (Kilograms(kilograms) * Grays(grays)) &&
       Joules(kilograms * grays) =~ (Grays(grays) * Kilograms(kilograms)) &&
       Grays(grays) =~ (Joules(kilograms * grays) / Kilograms(kilograms)) &&
       Kilograms(kilograms) =~ (Joules(kilograms * grays) / Grays(grays))
   }
 
-  property("Joules = CubicMeters * JoulesPerCubicMeter") = forAll(posNum, posNum) { (cubicMeters: TestData, jpcm: TestData) ⇒
+  property("Joules = CubicMeters * JoulesPerCubicMeter") = forAll(posNum, posNum) { (cubicMeters: TestData, jpcm: TestData) =>
     Joules(cubicMeters * jpcm) =~ (CubicMeters(cubicMeters) * JoulesPerCubicMeter(jpcm)) &&
       Joules(cubicMeters * jpcm) =~ (JoulesPerCubicMeter(jpcm) * CubicMeters(cubicMeters)) &&
       JoulesPerCubicMeter(jpcm) =~ (Joules(cubicMeters * jpcm) / CubicMeters(cubicMeters)) &&
       CubicMeters(cubicMeters) =~ (Joules(cubicMeters * jpcm) / JoulesPerCubicMeter(jpcm))
   }
 
-  property("Joules = JoulesPerKelvin * Kelvin") = forAll(posNum, posNum) { (joulesPerKelvin: TestData, kelvin: TestData) ⇒
+  property("Joules = JoulesPerKelvin * Kelvin") = forAll(posNum, posNum) { (joulesPerKelvin: TestData, kelvin: TestData) =>
     Joules(joulesPerKelvin * kelvin) =~ (JoulesPerKelvin(joulesPerKelvin) * Kelvin(kelvin)) &&
       Joules(joulesPerKelvin * kelvin) =~ (Kelvin(kelvin) * JoulesPerKelvin(joulesPerKelvin)) &&
       Kelvin(kelvin) =~ (Joules(joulesPerKelvin * kelvin) / JoulesPerKelvin(joulesPerKelvin)) &&
       JoulesPerKelvin(joulesPerKelvin) =~ (Joules(joulesPerKelvin * kelvin) / Kelvin(kelvin))
   }
 
-  property("Joules = Volt * Coulombs") = forAll(posNum, posNum) { (volts: TestData, coulombs: TestData) ⇒
+  property("Joules = Volt * Coulombs") = forAll(posNum, posNum) { (volts: TestData, coulombs: TestData) =>
     Joules(volts * coulombs) =~ (Volts(volts) * Coulombs(coulombs)) &&
       Joules(volts * coulombs) =~ (Coulombs(coulombs) * Volts(volts)) &&
       Coulombs(coulombs) =~ (Joules(volts * coulombs) / Volts(volts)) &&

--- a/shared/src/test/scala/squants/market/MarketChecks.scala
+++ b/shared/src/test/scala/squants/market/MarketChecks.scala
@@ -19,28 +19,28 @@ import org.scalacheck.Prop._
  */
 object MarketChecks extends Properties("Market") with QuantityChecks {
 
-  property("Money + Money = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
+  property("Money + Money = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) =>
     USD(a + b) == USD(a) + USD(b)
   }
 
-  property("Money - Money = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
+  property("Money - Money = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) =>
     USD(a - b) == USD(a) - USD(b)
   }
 
-  property("Money * Double = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
+  property("Money * Double = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) =>
     USD(a * b) == USD(a) * b.toDouble
   }
 
-  property("Money / Double = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
+  property("Money / Double = Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) =>
     USD(BigDecimal(a) / b) == USD(a) / b.toDouble
   }
 
-  property("Money = ExchangeRate * Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
+  property("Money = ExchangeRate * Money") = forAll(posNum, posNum) { (a: TestData, b: TestData) =>
     USD(BigDecimal(b) / a) == CurrencyExchangeRate(USD(1), JPY(a)) * JPY(b) &&
       USD(BigDecimal(b) / a) == JPY(b) * CurrencyExchangeRate(USD(1), JPY(a))
   }
 
-  property("(variations of) Money * Double + Money * Double = (Money * Double) * 2") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
+  property("(variations of) Money * Double + Money * Double = (Money * Double) * 2") = forAll(posNum, posNum) { (a: TestData, b: TestData) =>
     val m = USD(a.toDouble)
     val x = b.toDouble
 
@@ -54,7 +54,7 @@ object MarketChecks extends Properties("Market") with QuantityChecks {
       x * m + m * x == ((x * m) * 2)
   }
 
-  property("Money / Double + Money / Double = (Money / Double) * 2") = forAll(posNum, posNum) { (a: TestData, b: TestData) ⇒
+  property("Money / Double + Money / Double = (Money / Double) * 2") = forAll(posNum, posNum) { (a: TestData, b: TestData) =>
     implicit val tolUSD: Money = USD(1e-30)
     val m = if (a > 0) USD(a.toDouble) else USD(1)
     val x = if (b > 0) b.toDouble else 1d

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -93,19 +93,19 @@ class MoneySpec extends AnyFlatSpec with Matchers with TryValues {
   it should "return proper result when comparing dislike currencies with a MoneyContext in scope" in {
     implicit val moneyContext: MoneyContext = defaultMoneyContext.withExchangeRates(List(USD(1) -> JPY(100)))
 
-    USD(10) moneyEquals JPY(1000) should be(right = true)
+    USD(10).moneyEquals(JPY(1000)) should be(right = true)
     USD(10) ==# JPY(1000) should be(right = true)
-    USD(10) moneyEquals JPY(2000) should be(right = false)
+    USD(10).moneyEquals(JPY(2000)) should be(right = false)
     USD(10) ==# JPY(2000) should be(right = false)
 
-    USD(10) moneyNotEquals JPY(1000) should be(right = false)
+    USD(10).moneyNotEquals(JPY(1000)) should be(right = false)
     USD(10) !=# JPY(1000) should be(right = false)
-    USD(10) moneyNotEquals JPY(2000) should be(right = true)
+    USD(10).moneyNotEquals(JPY(2000)) should be(right = true)
     USD(10) !=# JPY(2000) should be(right = true)
 
-    USD(1) moneyCompare JPY(100) should be(0)
-    USD(1) moneyCompare JPY(1000) should be(-1)
-    USD(1) moneyCompare JPY(10) should be(1)
+    USD(1).moneyCompare(JPY(100)) should be(0)
+    USD(1).moneyCompare(JPY(1000)) should be(-1)
+    USD(1).moneyCompare(JPY(10)) should be(1)
 
     USD(1) ># JPY(99) should be(right = true)
     USD(1) ># JPY(100) should be(right = false)
@@ -363,8 +363,8 @@ class MoneySpec extends AnyFlatSpec with Matchers with TryValues {
   }
 
   it should "return an Exchange Rate on toThe (->) a different currency" in {
-    JPY(100) toThe USD(1) should be(CurrencyExchangeRate(USD(1), JPY(100)))
-    USD(1) toThe JPY(100) should be(CurrencyExchangeRate(JPY(100), USD(1)))
+    JPY(100).toThe(USD(1)) should be(CurrencyExchangeRate(USD(1), JPY(100)))
+    USD(1).toThe(JPY(100)) should be(CurrencyExchangeRate(JPY(100), USD(1)))
     JPY(100) -> USD(1) should be(CurrencyExchangeRate(USD(1), JPY(100)))
     USD(1) -> JPY(100) should be(CurrencyExchangeRate(JPY(100), USD(1)))
   }
@@ -394,19 +394,19 @@ class MoneySpec extends AnyFlatSpec with Matchers with TryValues {
     val r2 = CurrencyExchangeRate(USD(1), EUR(.75))
     implicit val moneyContext: MoneyContext = MoneyContext(USD, defaultCurrencySet, List(r1, r2))
 
-    USD(1.5) in JPY should be(JPY(150))
-    USD(1) in EUR should be(EUR(0.75))
-    JPY(100) in USD should be(USD(1))
-    EUR(75) in USD should be(USD(100))
-    EUR(75) in JPY should be(JPY(10000)) // Uses indirect rate via USD
-    JPY(100) in EUR should be(EUR(0.75)) // Uses indirect rate via USD
+    USD(1.5).in(JPY) should be(JPY(150))
+    USD(1).in(EUR) should be(EUR(0.75))
+    JPY(100).in(USD) should be(USD(1))
+    EUR(75).in(USD) should be(USD(100))
+    EUR(75).in(JPY) should be(JPY(10000)) // Uses indirect rate via USD
+    JPY(100).in(EUR) should be(EUR(0.75)) // Uses indirect rate via USD
 
-    USD(1.5) to JPY should be(150)
-    USD(1) to EUR should be(0.75)
-    JPY(100) to USD should be(1)
-    EUR(75) to USD should be(100)
-    EUR(75) to JPY should be(10000) // Uses indirect rate via USD
-    JPY(100) to EUR should be(0.75) // Uses indirect rate via USD
+    USD(1.5).to(JPY) should be(150)
+    USD(1).to(EUR) should be(0.75)
+    JPY(100).to(USD) should be(1)
+    EUR(75).to(USD) should be(100)
+    EUR(75).to(JPY) should be(10000) // Uses indirect rate via USD
+    JPY(100).to(EUR) should be(0.75) // Uses indirect rate via USD
   }
 
   it should "not compile cross currency conversions with no implicit MoneyContext in scope" in {
@@ -440,7 +440,7 @@ class MoneySpec extends AnyFlatSpec with Matchers with TryValues {
   }
 
   it should "return properly formatted strings in different currency with an implicit MoneyContext in scope" in {
-    implicit val moneyContext: MoneyContext = MoneyContext(USD, defaultCurrencySet, Seq(USD(1) toThe JPY(100)))
+    implicit val moneyContext: MoneyContext = MoneyContext(USD, defaultCurrencySet, Seq(USD(1).toThe(JPY(100))))
     USD(BigDecimal("10.123")).toString(JPY) should be("1012.3 JPY")
     USD(BigDecimal("10.123")).toFormattedString(JPY) should be("¥1012")
   }

--- a/shared/src/test/scala/squants/market/PriceSpec.scala
+++ b/shared/src/test/scala/squants/market/PriceSpec.scala
@@ -128,13 +128,13 @@ class PriceSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "convert a Price to a different currency with a valid MoneyContext" in {
-    implicit val moneyContext: MoneyContext = MoneyContext(USD, defaultCurrencySet, Seq(USD(1) toThe JPY(100)))
+    implicit val moneyContext: MoneyContext = MoneyContext(USD, defaultCurrencySet, Seq(USD(1).toThe(JPY(100))))
     val p = Price(USD(10), Meters(1))
-    p in JPY should be(Price(USD(10) in JPY, Meters(1)))
+    p.in(JPY) should be(Price(USD(10).in(JPY), Meters(1)))
   }
 
   it should "return a properly formatted string converted to different currency and/or unit with a valid MoneyContext" in {
-    implicit val moneyContext: MoneyContext = MoneyContext(USD, defaultCurrencySet, Seq(USD(1) toThe JPY(100)))
+    implicit val moneyContext: MoneyContext = MoneyContext(USD, defaultCurrencySet, Seq(USD(1).toThe(JPY(100))))
     val p = Price(USD(10), Meters(1))
     p.toString(JPY, Yards) should be(p.money.in(JPY).toString + "/" + p.quantity.toString(Yards))
   }

--- a/shared/src/test/scala/squants/mass/MassChecks.scala
+++ b/shared/src/test/scala/squants/mass/MassChecks.scala
@@ -20,14 +20,14 @@ import squants.space.{ CubicMeters, SquareMeters }
  */
 object MassChecks extends Properties("Mass") with QuantityChecks {
 
-  property("Mass = Density * Volume") = forAll(posNum, posNum) { (density: TestData, volume: TestData) ⇒
+  property("Mass = Density * Volume") = forAll(posNum, posNum) { (density: TestData, volume: TestData) =>
     Kilograms(density * volume) == KilogramsPerCubicMeter(density) * CubicMeters(volume) &&
       Kilograms(density * volume) == CubicMeters(volume) * KilogramsPerCubicMeter(density) &&
       KilogramsPerCubicMeter(density) == Kilograms(density * volume) / CubicMeters(volume) &&
       CubicMeters(volume) == Kilograms(density * volume) / KilogramsPerCubicMeter(density)
   }
 
-  property("Mass = AreaDensity * Area") = forAll(posNum, posNum) { (density: TestData, area: TestData) ⇒
+  property("Mass = AreaDensity * Area") = forAll(posNum, posNum) { (density: TestData, area: TestData) =>
     Kilograms(density * area) == KilogramsPerSquareMeter(density) * SquareMeters(area) &&
       Kilograms(density * area) == SquareMeters(area) * KilogramsPerSquareMeter(density) &&
       KilogramsPerSquareMeter(density) == Kilograms(density * area) / SquareMeters(area) &&

--- a/shared/src/test/scala/squants/mass/MassSpec.scala
+++ b/shared/src/test/scala/squants/mass/MassSpec.scala
@@ -195,7 +195,7 @@ class MassSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return MomentOfInertia when onRadius of Length" in {
-    Kilograms(1) onRadius Meters(1) should be(KilogramsMetersSquared(1))
+    Kilograms(1).onRadius(Meters(1)) should be(KilogramsMetersSquared(1))
   }
 
   behavior of "MassConversions"

--- a/shared/src/test/scala/squants/mass/MomentOfInertiaSpec.scala
+++ b/shared/src/test/scala/squants/mass/MomentOfInertiaSpec.scala
@@ -51,7 +51,7 @@ class MomentOfInertiaSpec extends AnyFlatSpec with Matchers with CustomMatchers 
   }
 
   it should "return mass when atCenter is called" in {
-    unitValueSi atCenter Meters(1) should be(Kilograms(1))
+    unitValueSi.atCenter(Meters(1)) should be(Kilograms(1))
   }
 
   it should "provide aliases for single unit values" in {

--- a/shared/src/test/scala/squants/motion/AngularAccelerationSpec.scala
+++ b/shared/src/test/scala/squants/motion/AngularAccelerationSpec.scala
@@ -51,7 +51,7 @@ class AngularAccelerationSpec extends AnyFlatSpec with Matchers{
   }
 
   it should "return Acceleration of particle onRadius of AngularAcceleration" in {
-    RadiansPerSecondSquared(1) onRadius Meters(1) should be(MetersPerSecondSquared(1))
+    RadiansPerSecondSquared(1).onRadius(Meters(1)) should be(MetersPerSecondSquared(1))
   }
 
   behavior of "AngularAccelerationConversions"

--- a/shared/src/test/scala/squants/motion/AngularVelocitySpec.scala
+++ b/shared/src/test/scala/squants/motion/AngularVelocitySpec.scala
@@ -63,7 +63,7 @@ class AngularVelocitySpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return Velocity of particle onRadius of AngularVelocity" in {
-    RadiansPerSecond(1) onRadius Meters(1) should be(MetersPerSecond(1))
+    RadiansPerSecond(1).onRadius(Meters(1)) should be(MetersPerSecond(1))
   }
 
   behavior of "AngularVelocityConversions"

--- a/shared/src/test/scala/squants/motion/MotionChecks.scala
+++ b/shared/src/test/scala/squants/motion/MotionChecks.scala
@@ -28,63 +28,63 @@ object MotionChecks extends Properties("Motion") with QuantityChecks {
   implicit val tolMfr: MassFlow = KilogramsPerSecond(tol)
   implicit val tolVfr: VolumeFlow = CubicMetersPerSecond(tol)
 
-  property("Distance = Velocity * Time") = forAll(posNum, posNum) { (velocity: TestData, time: TestData) ⇒
+  property("Distance = Velocity * Time") = forAll(posNum, posNum) { (velocity: TestData, time: TestData) =>
     Meters(velocity * time) == MetersPerSecond(velocity) * Seconds(time) &&
       Meters(velocity * time) == Seconds(time) * MetersPerSecond(velocity) &&
       Seconds(time) =~ Meters(velocity * time) / MetersPerSecond(velocity) &&
       MetersPerSecond(velocity) =~ Meters(velocity * time) / Seconds(time)
   }
 
-  property("Velocity = Acceleration * Time") = forAll(posNum, posNum) { (acc: TestData, time: TestData) ⇒
+  property("Velocity = Acceleration * Time") = forAll(posNum, posNum) { (acc: TestData, time: TestData) =>
     MetersPerSecond(acc * time) == MetersPerSecondSquared(acc) * Seconds(time) &&
       MetersPerSecond(acc * time) == Seconds(time) * MetersPerSecondSquared(acc) &&
       Seconds(time) =~ MetersPerSecond(acc * time) / MetersPerSecondSquared(acc) &&
       MetersPerSecondSquared(acc) =~ MetersPerSecond(acc * time) / Seconds(time)
   }
 
-  property("Acceleration = Jerk * Time") = forAll(posNum, posNum) { (jerk: TestData, time: TestData) ⇒
+  property("Acceleration = Jerk * Time") = forAll(posNum, posNum) { (jerk: TestData, time: TestData) =>
     MetersPerSecondSquared(jerk * time) == MetersPerSecondCubed(jerk) * Seconds(time) &&
       MetersPerSecondSquared(jerk * time) == Seconds(time) * MetersPerSecondCubed(jerk) &&
       Seconds(time) =~ MetersPerSecondSquared(jerk * time) / MetersPerSecondCubed(jerk) &&
       MetersPerSecondCubed(jerk) =~ MetersPerSecondSquared(jerk * time) / Seconds(time)
   }
 
-  property("Momentum = Velocity * Mass") = forAll(posNum, posNum) { (velocity: TestData, mass: TestData) ⇒
+  property("Momentum = Velocity * Mass") = forAll(posNum, posNum) { (velocity: TestData, mass: TestData) =>
     NewtonSeconds(velocity * mass) == MetersPerSecond(velocity) * Kilograms(mass) &&
       NewtonSeconds(velocity * mass) == Kilograms(mass) * MetersPerSecond(velocity) &&
       Kilograms(mass) == NewtonSeconds(velocity * mass) / MetersPerSecond(velocity) &&
       MetersPerSecond(velocity).plusOrMinus(MetersPerSecond(tol)).contains(NewtonSeconds(velocity * mass) / Kilograms(mass))
   }
 
-  property("Force = Acceleration * Mass") = forAll(posNum, posNum) { (acc: TestData, mass: TestData) ⇒
+  property("Force = Acceleration * Mass") = forAll(posNum, posNum) { (acc: TestData, mass: TestData) =>
     Newtons(acc * mass) == MetersPerSecondSquared(acc) * Kilograms(mass) &&
       Newtons(acc * mass) == Kilograms(mass) * MetersPerSecondSquared(acc) &&
       MetersPerSecondSquared(acc) == Newtons(acc * mass) / Kilograms(mass) &&
       Kilograms(mass).plusOrMinus(Kilograms(tol)).contains(Newtons(acc * mass) / MetersPerSecondSquared(acc))
   }
 
-  property("Momentum = Force * Time") = forAll(posNum, posNum) { (force: TestData, time: TestData) ⇒
+  property("Momentum = Force * Time") = forAll(posNum, posNum) { (force: TestData, time: TestData) =>
     NewtonSeconds(force * time) == Newtons(force) * Seconds(time) &&
       NewtonSeconds(force * time) == Seconds(time) * Newtons(force) &&
       Seconds(time) =~ NewtonSeconds(force * time) / Newtons(force) &&
       Newtons(force).plusOrMinus(Newtons(tol)).contains(NewtonSeconds(force * time) / Seconds(time))
   }
 
-  property("Force = Pressure * Area") = forAll(posNum, posNum) { (pressure: TestData, area: TestData) ⇒
+  property("Force = Pressure * Area") = forAll(posNum, posNum) { (pressure: TestData, area: TestData) =>
     Newtons(pressure * area) == Pascals(pressure) * SquareMeters(area) &&
       Newtons(pressure * area) == SquareMeters(area) * Pascals(pressure) &&
       Pascals(pressure) == Newtons(pressure * area) / SquareMeters(area) &&
       SquareMeters(area) == Newtons(pressure * area) / Pascals(pressure)
   }
 
-  property("Mass = MassFlowRate * Time") = forAll(posNum, posNum) { (flowRate: TestData, time: TestData) ⇒
+  property("Mass = MassFlowRate * Time") = forAll(posNum, posNum) { (flowRate: TestData, time: TestData) =>
     Kilograms(flowRate * time) == KilogramsPerSecond(flowRate) * Seconds(time) &&
       Kilograms(flowRate * time) == Seconds(time) * KilogramsPerSecond(flowRate) &&
       Seconds(time) =~ Kilograms(flowRate * time) / KilogramsPerSecond(flowRate) &&
       KilogramsPerSecond(flowRate) =~ Kilograms(flowRate * time) / Seconds(time)
   }
 
-  property("Volume = VolumeFlowRate * Time") = forAll(posNum, posNum) { (flowRate: TestData, time: TestData) ⇒
+  property("Volume = VolumeFlowRate * Time") = forAll(posNum, posNum) { (flowRate: TestData, time: TestData) =>
     CubicMeters(flowRate * time) == CubicMetersPerSecond(flowRate) * Seconds(time) &&
       CubicMeters(flowRate * time) == Seconds(time) * CubicMetersPerSecond(flowRate) &&
       Seconds(time) =~ CubicMeters(flowRate * time) / CubicMetersPerSecond(flowRate) &&

--- a/shared/src/test/scala/squants/photo/PhotoChecks.scala
+++ b/shared/src/test/scala/squants/photo/PhotoChecks.scala
@@ -24,35 +24,35 @@ object PhotoChecks extends Properties("Photo") with QuantityChecks {
   implicit val tolLumFlux: LuminousFlux = Lumens(tol)
   implicit val tolIllum: Illuminance = Lux(tol)
 
-  property("Lumens = Lux * SquareMeters") = forAll(posNum, posNum) { (lux: TestData, sm: TestData) ⇒
+  property("Lumens = Lux * SquareMeters") = forAll(posNum, posNum) { (lux: TestData, sm: TestData) =>
     Lumens(lux * sm) == Lux(lux) * SquareMeters(sm) &&
       Lumens(lux * sm) == SquareMeters(sm) * Lux(lux) &&
       Lux(lux) == Lumens(lux * sm) / SquareMeters(sm) &&
       SquareMeters(sm) == Lumens(lux * sm) / Lux(lux)
   }
 
-  property("LuxSeconds = Lux * Seconds") = forAll(posNum, posNum) { (lux: TestData, seconds: TestData) ⇒
+  property("LuxSeconds = Lux * Seconds") = forAll(posNum, posNum) { (lux: TestData, seconds: TestData) =>
     LuxSeconds(lux * seconds) == Lux(lux) * Seconds(seconds) &&
       LuxSeconds(lux * seconds) == Seconds(seconds) * Lux(lux) &&
       Lux(lux) =~ LuxSeconds(lux * seconds) / Seconds(seconds) &&
       Seconds(seconds) =~ LuxSeconds(lux * seconds) / Lux(lux)
   }
 
-  property("Candelas = CandelasPerSquareMeter * SquareMeters") = forAll(posNum, posNum) { (cpsm: TestData, sm: TestData) ⇒
+  property("Candelas = CandelasPerSquareMeter * SquareMeters") = forAll(posNum, posNum) { (cpsm: TestData, sm: TestData) =>
     Candelas(cpsm * sm) == CandelasPerSquareMeter(cpsm) * SquareMeters(sm) &&
       Candelas(cpsm * sm) == SquareMeters(sm) * CandelasPerSquareMeter(cpsm) &&
       CandelasPerSquareMeter(cpsm) == Candelas(cpsm * sm) / SquareMeters(sm) &&
       SquareMeters(sm) == Candelas(cpsm * sm) / CandelasPerSquareMeter(cpsm)
   }
 
-  property("LumenSeconds = Lumens * Seconds") = forAll(posNum, posNum) { (lumens: TestData, seconds: TestData) ⇒
+  property("LumenSeconds = Lumens * Seconds") = forAll(posNum, posNum) { (lumens: TestData, seconds: TestData) =>
     LumenSeconds(lumens * seconds) == Lumens(lumens) * Seconds(seconds) &&
       LumenSeconds(lumens * seconds) == Seconds(seconds) * Lumens(lumens) &&
       Lumens(lumens) =~ LumenSeconds(lumens * seconds) / Seconds(seconds) &&
       Seconds(seconds) =~ LumenSeconds(lumens * seconds) / Lumens(lumens)
   }
 
-  property("Lumens = Candelas * SquaredRadians") = forAll(posNum, posNum) { (candelas: TestData, sqRadians: TestData) ⇒
+  property("Lumens = Candelas * SquaredRadians") = forAll(posNum, posNum) { (candelas: TestData, sqRadians: TestData) =>
     Lumens(candelas * sqRadians) == Candelas(candelas) * SquaredRadians(sqRadians) &&
       Lumens(candelas * sqRadians) == SquaredRadians(sqRadians) * Candelas(candelas) &&
       Candelas(candelas) == Lumens(candelas * sqRadians) / SquaredRadians(sqRadians) &&

--- a/shared/src/test/scala/squants/radio/RadioChecks.scala
+++ b/shared/src/test/scala/squants/radio/RadioChecks.scala
@@ -21,35 +21,35 @@ import squants.space.{ Meters, SquareMeters, SquaredRadians }
  */
 object RadioChecks extends Properties("Radio") with QuantityChecks {
 
-  property("Power = Irradiance * Area") = forAll(posNum, posNum) { (irr: TestData, area: TestData) ⇒
+  property("Power = Irradiance * Area") = forAll(posNum, posNum) { (irr: TestData, area: TestData) =>
     Watts(irr * area) == WattsPerSquareMeter(irr) * SquareMeters(area) &&
       Watts(irr * area) == SquareMeters(area) * WattsPerSquareMeter(irr) &&
       SquareMeters(area) == Watts(irr * area) / WattsPerSquareMeter(irr) &&
       WattsPerSquareMeter(irr) == Watts(irr * area) / SquareMeters(area)
   }
 
-  property("RadiantIntensity = Radiance * Area") = forAll(posNum, posNum) { (rad: TestData, area: TestData) ⇒
+  property("RadiantIntensity = Radiance * Area") = forAll(posNum, posNum) { (rad: TestData, area: TestData) =>
     WattsPerSteradian(rad * area) == WattsPerSteradianPerSquareMeter(rad) * SquareMeters(area) &&
       WattsPerSteradian(rad * area) == SquareMeters(area) * WattsPerSteradianPerSquareMeter(rad) &&
       SquareMeters(area) == WattsPerSteradian(rad * area) / WattsPerSteradianPerSquareMeter(rad) &&
       WattsPerSteradianPerSquareMeter(rad) == WattsPerSteradian(rad * area) / SquareMeters(area)
   }
 
-  property("Power = RadiantIntensity * SolidAngle") = forAll(posNum, posNum) { (rad: TestData, solidAngle: TestData) ⇒
+  property("Power = RadiantIntensity * SolidAngle") = forAll(posNum, posNum) { (rad: TestData, solidAngle: TestData) =>
     Watts(rad * solidAngle) == WattsPerSteradian(rad) * SquaredRadians(solidAngle) &&
       Watts(rad * solidAngle) == SquaredRadians(solidAngle) * WattsPerSteradian(rad) &&
       SquaredRadians(solidAngle) == Watts(rad * solidAngle) / WattsPerSteradian(rad) &&
       WattsPerSteradian(rad) == Watts(rad * solidAngle) / SquaredRadians(solidAngle)
   }
 
-  property("RadiantIntensity = SpectralIntensity * Length") = forAll(posNum, posNum) { (specInt: TestData, length: TestData) ⇒
+  property("RadiantIntensity = SpectralIntensity * Length") = forAll(posNum, posNum) { (specInt: TestData, length: TestData) =>
     WattsPerSteradian(specInt * length) == WattsPerSteradianPerMeter(specInt) * Meters(length) &&
       WattsPerSteradian(specInt * length) == Meters(length) * WattsPerSteradianPerMeter(specInt) &&
       Meters(length) == WattsPerSteradian(specInt * length) / WattsPerSteradianPerMeter(specInt) &&
       WattsPerSteradianPerMeter(specInt) == WattsPerSteradian(specInt * length) / Meters(length)
   }
 
-  property("Power = SpectralPower * Length") = forAll(posNum, posNum) { (specPower: TestData, length: TestData) ⇒
+  property("Power = SpectralPower * Length") = forAll(posNum, posNum) { (specPower: TestData, length: TestData) =>
     Watts(specPower * length) == WattsPerMeter(specPower) * Meters(length) &&
       Watts(specPower * length) == Meters(length) * WattsPerMeter(specPower) &&
       Meters(length).plusOrMinus(Meters(tol)).contains(Watts(specPower * length) / WattsPerMeter(specPower)) &&

--- a/shared/src/test/scala/squants/space/AngleSpec.scala
+++ b/shared/src/test/scala/squants/space/AngleSpec.scala
@@ -87,7 +87,7 @@ class AngleSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return Length when angle is arc on circle" in {
-    Radians(1) onRadius Meters(1) should be(Meters(1))
+    Radians(1).onRadius(Meters(1)) should be(Meters(1))
   }
 
   behavior of "AngleConversion"

--- a/shared/src/test/scala/squants/space/SpaceChecks.scala
+++ b/shared/src/test/scala/squants/space/SpaceChecks.scala
@@ -24,26 +24,26 @@ object SpaceChecks extends Properties("Space") with QuantityChecks {
   implicit val tolVfr: VolumeFlow = CubicMetersPerSecond(tol)
   implicit val tolAngularVelocity: AngularVelocity = RadiansPerSecond(tol)
 
-  property("Area = Length * Length") = forAll(posNum, posNum) { (length1: TestData, length2: TestData) ⇒
+  property("Area = Length * Length") = forAll(posNum, posNum) { (length1: TestData, length2: TestData) =>
     SquareMeters(length1 * length2) == Meters(length1) * Meters(length2) &&
       Meters(length1) == SquareMeters(length1 * length2) / Meters(length2)
   }
 
-  property("Volume = Length * Area") = forAll(posNum, posNum) { (length: TestData, area: TestData) ⇒
+  property("Volume = Length * Area") = forAll(posNum, posNum) { (length: TestData, area: TestData) =>
     CubicMeters(length * area) == Meters(length) * SquareMeters(area) &&
       CubicMeters(length * area) == SquareMeters(area) * Meters(length) &&
       Meters(length) == CubicMeters(length * area) / SquareMeters(area) &&
       SquareMeters(area) == CubicMeters(length * area) / Meters(length)
   }
 
-  property("Volume = VolumeFlowRate * Time") = forAll(posNum, posNum) { (vfr: TestData, time: TestData) ⇒
+  property("Volume = VolumeFlowRate * Time") = forAll(posNum, posNum) { (vfr: TestData, time: TestData) =>
     CubicMeters(vfr * time) == CubicMetersPerSecond(vfr) * Seconds(time) &&
       CubicMeters(vfr * time) == Seconds(time) * CubicMetersPerSecond(vfr) &&
       Seconds(time) =~ CubicMeters(vfr * time) / CubicMetersPerSecond(vfr) &&
       CubicMetersPerSecond(vfr) =~ CubicMeters(vfr * time) / Seconds(time)
   }
 
-  property("Angle = AngularVelocity * Time") = forAll(posNum, posNum) { (angularVel: TestData, time: TestData) ⇒
+  property("Angle = AngularVelocity * Time") = forAll(posNum, posNum) { (angularVel: TestData, time: TestData) =>
     Radians(angularVel * time) == RadiansPerSecond(angularVel) * Seconds(time) &&
       Radians(angularVel * time) == Seconds(time) * RadiansPerSecond(angularVel) &&
       Seconds(time) =~ Radians(angularVel * time) / RadiansPerSecond(angularVel) &&

--- a/shared/src/test/scala/squants/thermal/ThermalChecks.scala
+++ b/shared/src/test/scala/squants/thermal/ThermalChecks.scala
@@ -21,31 +21,31 @@ import squants.energy.Energy
  */
 object ThermalChecks extends Properties("Thermal") with QuantityChecks {
 
-  property("Celsius to Fahrenheit") = forAll { (a: Double) ⇒
+  property("Celsius to Fahrenheit") = forAll { (a: Double) =>
     Celsius(a).toFahrenheitScale == (a * 9d / 5) + 32d
   }
 
-  property("Celsius to Kelvin") = forAll { (a: Double) ⇒
+  property("Celsius to Kelvin") = forAll { (a: Double) =>
     Celsius(a).toKelvinScale == a + 273.15
   }
 
-  property("Fahrenheit to Celsius ") = forAll { (a: Double) ⇒
+  property("Fahrenheit to Celsius ") = forAll { (a: Double) =>
     Fahrenheit(a).toCelsiusScale == (a - 32d) * 5d / 9d
   }
 
-  property("Fahrenheit to Kelvin ") = forAll { (a: Double) ⇒
+  property("Fahrenheit to Kelvin ") = forAll { (a: Double) =>
     Fahrenheit(a).toKelvinScale == (a + 459.67) * 5d / 9d
   }
 
-  property("Kelvin to Fahrenheit") = forAll { (a: Double) ⇒
+  property("Kelvin to Fahrenheit") = forAll { (a: Double) =>
     Kelvin(a).toFahrenheitScale == (a * 9d / 5) - 459.67
   }
 
-  property("Kelvin to Celsius") = forAll { (a: Double) ⇒
+  property("Kelvin to Celsius") = forAll { (a: Double) =>
     Kelvin(a).toCelsiusScale == a - 273.15
   }
 
-  property("ThermalCapacity * Temperature = Energy") = forAll(posNum, posNum) { (thermCap: TestData, temp: TestData) ⇒
+  property("ThermalCapacity * Temperature = Energy") = forAll(posNum, posNum) { (thermCap: TestData, temp: TestData) =>
 
     implicit val tempTol: Temperature = Kelvin(tol)
     implicit val thermTol: ThermalCapacity = JoulesPerKelvin(tol)

--- a/shared/src/test/scala/squants/time/SecondTimeDerivativeSpec.scala
+++ b/shared/src/test/scala/squants/time/SecondTimeDerivativeSpec.scala
@@ -25,7 +25,7 @@ class SecondTimeDerivativeSpec extends AnyFlatSpec with Matchers with CustomMatc
 
   it should "satisfy Derivative^2 = Integral / TimeSquared" in {
     MetersPerSecondSquared(55) should be(Meters(55) / SecondsSquared(1))
-    MetersPerSecondSquared(55) should be(Meters(55) per SecondsSquared(1))
+    MetersPerSecondSquared(55) should be(Meters(55).per(SecondsSquared(1)))
   }
 
   it should "satisfy Integral = Derivative^2 * TimeSquared" in {

--- a/shared/src/test/scala/squants/time/TimeChecks.scala
+++ b/shared/src/test/scala/squants/time/TimeChecks.scala
@@ -21,23 +21,23 @@ object TimeChecks extends Properties("Time") with QuantityChecks {
 
   implicit val tolFreq: Frequency = Hertz(tol)
 
-  property("Milliseconds = Seconds * 1000") = forAll(posNum) { (seconds: TestData) ⇒
+  property("Milliseconds = Seconds * 1000") = forAll(posNum) { (seconds: TestData) =>
     Milliseconds(seconds * 1000) == Seconds(seconds)
   }
 
-  property("Seconds = Minutes * 60") = forAll(posNum) { (minutes: TestData) ⇒
+  property("Seconds = Minutes * 60") = forAll(posNum) { (minutes: TestData) =>
     Seconds(minutes * 60) == Minutes(minutes)
   }
 
-  property("Minutes = Hours * 60") = forAll(posNum) { (hours: TestData) ⇒
+  property("Minutes = Hours * 60") = forAll(posNum) { (hours: TestData) =>
     Minutes(hours * 60) == Hours(hours)
   }
 
-  property("Hours = Days * 24") = forAll(posNum) { (days: TestData) ⇒
+  property("Hours = Days * 24") = forAll(posNum) { (days: TestData) =>
     Hours(days * 24) == Days(days)
   }
 
-  property("Count = Frequency * Time") = forAll(posNum, posNum) { (freq: TestData, time: TestData) ⇒
+  property("Count = Frequency * Time") = forAll(posNum, posNum) { (freq: TestData, time: TestData) =>
     Each(freq * time) == Hertz(freq) * Seconds(time)
     Each(freq * time) == Seconds(time) * Hertz(freq)
     Seconds(time) =~ Each(freq * time) / Hertz(freq)


### PR DESCRIPTION
I needed a 0.5 scala native version of squants. After doing that I also updated the version of scala, sbt and other libraries to their most recent version. That created a bunch of deprecated warnings, so I changed the code as suggested in the warnings to remove them.  I published the artifacts locally so I'm happy, but I thought maybe the changes would be useful upstream.  